### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ It is very much a work in progress.
 ## The Specification
 
 The Console Specification is written in [`Bikeshed`](https://github.com/tabatkins/bikeshed) and is tracked in this repository as `index.bs`.
-It will soon be visible at [https://terinjokes.github.io/console-spec]().
+It will soon be visible at [https://terinjokes.github.io/console-spec](http://terinjokes.github.io/console-spec/).


### PR DESCRIPTION
In the GH web view, the link ends up linking to "https://github.com/terinjokes/console-spec/blob/master" instead of the actual URL.
