### PR TITLE
update URLs for whatwg organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ It is very much a work in progress.
 ## The Specification
 
 The Console Specification is written in [`Bikeshed`](https://github.com/tabatkins/bikeshed) and is tracked in this repository as `index.bs`.
-The latest rendered version can be viewed at <https://terinjokes.github.io/console-spec>.
+The latest rendered version can be viewed at <https://whatwg.github.io/console>.

--- a/index.bs
+++ b/index.bs
@@ -5,12 +5,12 @@ H1: Console
 Shortname: console
 Level: 1
 Status: DREAM
-ED: https://terinjokes.github.io/console-spec
+ED: https://whatwg.github.io/console
 Editor: Terin Stock, https://terinstock.com, terin@terinstock.com
 Abstract: This specification standardizes APIs for console debugging facilities.
-Logo: https://cdn.rawgit.com/terinjokes/console-spec/dd485319b0d0c918d954e0daafd349c9387c6e8c/logo.svg
-!Version History: <a href="https://github.com/terinjokes/console-spec/commits">https://github.com/terinjokes/console-spec/commits</a>
-!Participate: <a href="https://github.com/terinjokes/console-spec/issues/new">File an issue</a> (<a href="https://github.com/terinjokes/console-spec/issues?state=open">open issues</a>)
+Logo: https://cdn.rawgit.com/whatwg/console/dd485319b0d0c918d954e0daafd349c9387c6e8c/logo.svg
+!Version History: <a href="https://github.com/whatwg/console/commits">https://github.com/whatwg/console/commits</a>
+!Participate: <a href="https://github.com/whatwg/console/issues/new">File an issue</a> (<a href="https://github.com/whatwg/console/issues?state=open">open issues</a>)
 !Participate: Send feedback to <a href="http://www.whatwg.org/mailing-list">whatwg@whatwg.org</a> (<a href="http://www.whatwg.org/mailing-list#specs">archives</a>)
 !Participate: <a href="http://wiki.whatwg.org/wiki/IRC">IRC: #whatwg on Freenode</a>
 
@@ -43,7 +43,7 @@ Link Defaults: html (dfn) structured clone
 This specification is in the process of establishing itself in the WHATWG.
 As such, the term "Living Standard" indicates a goal, rather than reality.
 
-Please join us in the <a href="https://github.com/terinjokes/console-spec/issues?state=open">issue tracker</a> for more discussion.
+Please join us in the <a href="https://github.com/whatwg/console/issues?state=open">issue tracker</a> for more discussion.
 
 <h2 id="logger-function">Logger Function</h2>
 The logging function accepts datum and the logLevel, which is stored or displayed in a platform appropriate way.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "console-spec",
+  "name": "console",
   "private": true,
   "version": "1.0.0",
   "description": "For several users most web browsers have shipped some form of JavaScript developer console. Unfortunately, without a standard specification, each browser has implemented the language bindings of this console differently.",
   "repository": {
     "type": "git",
-    "url": "terinjokes/console-spec"
+    "url": "whatwg/console"
   },
   "author": "Terin Stock <terinjokes@gmail.com> & Robert Kowalski <rok@kowalski.gd>",
   "license": "MIT",

--- a/test/package.json
+++ b/test/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/terinjokes/console-spec"
+    "url": "https://github.com/whatwg/console"
   },
   "keywords": [
     "console"
@@ -16,9 +16,9 @@
   "author": "Terin Stock <terinjokes@gmail.com> (https://terinstock.com/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/terinjokes/console-spec/issues"
+    "url": "https://github.com/whatwg/console/issues"
   },
-  "homepage": "https://github.com/terinjokes/console-spec",
+  "homepage": "https://github.com/whatwg/console",
   "dependencies": {
     "lodash": "^2.4.1",
     "mocha": "^1.21.4"


### PR DESCRIPTION
Might rewrite this PR depending on how quickly the console.whatwg.org domain appears.