### PR TITLE
Fix #24: abstract operations should now be autolinked

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -55,8 +55,8 @@ The logger operation accepts a log level and a List of other arguments. Its main
   1. Let _first_ be the first element of _args_. If _args_ is empty, abort these steps.
   1. Let _rest_ be all elements following _first_ in _args_.
   1. If _rest_ is empty, print _first_ to the console. Abort these steps.
-  1. If _first_ does not contain any format specifiers, perform Print(_logLevel_, _args_).
-  1. Otherwise, perform Print(_logLevel_, Formatter(_args_)).
+  1. If _first_ does not contain any format specifiers, perform Printer(_logLevel_, _args_).
+  1. Otherwise, perform Printer(_logLevel_, Formatter(_args_)).
   1. Return *undefined*.
 </emu-alg>
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
   "author": "Terin Stock <terinjokes@gmail.com> & Robert Kowalski <rok@kowalski.gd>",
   "license": "CC0",
   "devDependencies": {
-    "ecmarkup": "^1.3.0",
-    "emu-algify": "^1.0.0",
-    "jsdom": "^5.0.1"
+    "emu-algify": "^1.0.1"
   }
 }


### PR DESCRIPTION
Still some remaining issues: https://github.com/bterlson/ecmarkup/issues/77 and https://github.com/bterlson/ecmarkup/issues/76 but they are not our fault.