### PR TITLE
add difference when browsers return undefined

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -90,3 +90,22 @@ Chrome:
 console.log("%s %snewword", "duck")
 duck %snewword
 ```
+
+## Async printing execution
+
+It looks like FF is calling the Logger async, at least the console
+methods return `undefined` **before** printing:
+
+```
+console.count("foo")
+undefined
+foo: 1
+````
+
+Chrome:
+
+```
+console.count("foo")
+foo: 1
+undefined
+```


### PR DESCRIPTION
it looks like FF is working in an async way (returns undefined
before the logger prints) and that the Chrome implementation is
blocking until the printer printed.