### PR TITLE
Remove note about async execution, since behavior in Firefox matches spec as of Bug 1044365 (version 46)

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -90,22 +90,3 @@ Chrome:
 console.log("%s %snewword", "duck")
 duck %snewword
 ```
-
-## Async printing execution
-
-It looks like FF is calling the Logger async, at least the console
-methods return `undefined` **before** printing:
-
-```
-console.count("foo")
-undefined
-foo: 1
-````
-
-Chrome:
-
-```
-console.count("foo")
-foo: 1
-undefined
-```


### PR DESCRIPTION
I've updated the behavior in Firefox to match the spec in https://hg.mozilla.org/mozilla-central/rev/2903b0280572, so can the note be removed?  Version 46 will be promoted to the Dev Edition channel later this week.