### PR TITLE
Make format specifier spec more rigorous

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -63,7 +63,7 @@ The logger operation accepts a log level and a List of other arguments. Its main
 
 <h3 id="formatter" aoid="Formatter" nothrow>Formatter(<var>args</var>)</h3>
 
-The formatter operation tries to format the first argument provided, using the other arguments. It will try to format the input until no <a>formatting specifiers</a> are left in the first argument, or no more arguments are left. It returns a List of objects suitable for printing.
+The formatter operation tries to format the first argument provided, using the other arguments. It will try to format the input until no formatting specifiers are left in the first argument, or no more arguments are left. It returns a List of objects suitable for printing.
 
 <emu-alg>
   1. Let _target_ be the first element of _args_.
@@ -72,16 +72,64 @@ The formatter operation tries to format the first argument provided, using the o
     1. If _specifier_ is `%s`, let _converted_ be the result of ToString(_current_).
     1. If _specifier_ is `%d` or `%i`, let _converted_ be the result of %parseInt%(_current_, 10).
     1. If _specifier_ is `%f`, let _converted_ be the result of  %parseFloat%(_current_, 10).
-    1. Replace _specifier_ in _target_ with _converted_.
+    1. If _specifier_ is `%o`, optionally let _converted_ be an implementation-specific representation of _current_ that is judged to be maximally useful and informative.
+    1. If _specifier_ is `%O`, optionally let _converted_ be be an implementation-specific representation of _current_ as an expanded or expandable object, treating _current_ as a generic JavaScript object.
+    1. <p class="XXX">TODO: process %c</p>
+    1. If any of the previous steps set _converted_, replace _specifier_ in _target_ with _converted_.
     1. Let _result_ be a List containing _target_ together with the elements of _args_ starting from the third onward.
   1. If _target_ does not have any format specifiers left, return _result_.
   1. If _result_ contains just one element, return _result_.
   1. Return Formatter(_result_).
 </emu-alg>
 
+<h4 id="formatting-specifiers">Summary of formatting specifiers</h4>
+
+The following is an informative summary of the format specifiers processed by the above algorithm.
+
+<table>
+  <thead>
+    <tr>
+      <th>Specifier</th>
+      <th>Purpose</th>
+      <th>Type Conversion</th>
+    </tr>
+  </thead>
+  <tr>
+  <tr>
+    <td><code>%s</code></td>
+    <td>Element which substitutes is converted to a string</<td>
+    <td>ToString(<var>element</var>)</td>
+  </tr>
+  <tr>
+    <td><code>%d</code> or <code>%i</code></td>
+    <td>Element which substitutes is converted to an integer</<td>
+    <td>%parseInt%(<var>element</var>, 10)</td>
+  </tr>
+  <tr>
+    <td><code>%f</code></td>
+    <td>Element which substitutes is converted to a float</<td>
+    <td>%parseFloat%(<var>element</var>, 10)</td>
+  </tr>
+  <tr>
+    <td><code>%o</code></td>
+    <td>Element is displayed in an implementation-specific way judged as most useful; potentially interactive</<td>
+    <td>n/a</td>
+  </tr>
+  <tr>
+    <td><code>%O</code></td>
+    <td>Element is displayed as an expanded JavaScript object; potentially interactive</<td>
+    <td>n/a</td>
+  </tr>
+  <tr>
+    <td><code>%c</code></td>
+    <td>Applies provided CSS</<td>
+    <td>n/a</td>
+  </tr>
+</table>
+
 <h3 id="printer" aoid="Printer" nothrow>Printer(<var>logLevel</var>, <var>args</var>)</h3>
 
-The printer operation is implementation-defined. It accepts a log level indicating severity, and a List of arguments to print (which are JavaScript objects, of any type). How the implementation prints <var>args</var> is up to the implementation, but implementations should separate the objects by a space or something similar, as that has become a developer expectation.
+The printer operation is implementation-defined. It accepts a log level indicating severity, and a List of arguments to print (which are either JavaScript objects, of any type, or are implementation-specific representations of printable things, as produced by the <code>%o</code> and <code>%O</code> specifiers). How the implementation prints <var>args</var> is up to the implementation, but implementations should separate the objects by a space or something similar, as that has become a developer expectation.
 
 By the time the printer operation is called, all format specifiers will have been taken into account, and any arguments that are meant to be consumed by format specifiers will not be present in <var>args</var>. The implementation's job is simply to print the List.
 
@@ -190,7 +238,7 @@ Perform Logger("log", <var>data</var>).
 Try to construct a table with the columns of the properties of tabularData and rows of tabularData and log it with a logLevel of log.
 Fall back to just logging the argument if it can't be parsed as tabular.
 
-TODO: This will need a good algorithm.
+<p class="XXX">TODO: This will need a good algorithm.</p>
 
 <h4><dfn method for="Console">trace(...<var>data</var>)</dfn></h4>
 
@@ -220,68 +268,6 @@ Let <var>duration</var> be the current value of the internal timer with key <var
 Remove the timer from the timer table.
 Then, perform Logger("info", «<var>label</var>, <var>duration</var>»).
 
-
-<h2 id="formatting-specifiers"><dfn>Formatting specifiers</dfn></h2>
-
-<h3 id="formatting-no-ui">Formatting specifiers that don't require a complex UI</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Specifier</th>
-      <th>Function</th>
-      <th>Type Conversion</th>
-    </tr>
-  </thead>
-  <tr>
-  <tr>
-    <td>%s</td>
-    <td>Element which substitutes is converted to a String</<td>
-    <td>ToString(element)</td>
-  </tr>
-  <tr>
-    <td>%d</td>
-    <td>Element which substitutes is converted to an Integer</<td>
-    <td>%parseInt%(element, 10)</td>
-  </tr>
-  <tr>
-    <td>%i</td>
-    <td>Element which substitutes is converted to an Integer</<td>
-    <td>%parseInt%(element, 10)</td>
-  </tr>
-  <tr>
-    <td>%f</td>
-    <td>Element which substitutes is converted to a Float</<td>
-    <td>%parseFloat%(element, 10)</td>
-  </tr>
-</table>
-
-<h3 id="formatting-complex-ui">Formatting specifiers that require a complex UI</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Specifier</th>
-      <th>Function</th>
-      <th>Type Conversion</th>
-    </tr>
-  </thead>
- <tr>
-    <td>%o</td>
-    <td>Displays as expandable DOM element</<td>
-    <td>n/a</td>
-  </tr>
-  <tr>
-    <td>%O</td>
-    <td>Displays as expandable JS Object</<td>
-    <td>n/a</td>
-  </tr>
-  <tr>
-    <td>%c</td>
-    <td>Applies provided CSS</<td>
-    <td>n/a</td>
-  </tr>
-</table>
 
 <h2 id="inspection">JavaScript object inspection</h2>
 


### PR DESCRIPTION
Closes #25. Closes #36 by incorporating @paulirish's feedback that %o is a bit more generic than "expandable DOM object". Closes #33 by superseding it.

Let me know what you guys think :)