### PR TITLE
console.assert improvements

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -78,3 +78,32 @@ Chrome:
 console.log("%s %snewword", "duck")
 duck %snewword
 ```
+
+## console.assert
+
+```
+FF / Edge:
+
+console.assert(false, "robert keeps %s on his balcony", "plaices")
+robert keeps plaices on his balcony
+
+Chrome:
+
+console.assert(false, "robert keeps %s on his balcony", "plaices")
+Assertion failed: robert keeps %s on his balcony plaices
+```
+
+
+## console.assert
+
+```
+FF / Edge:
+
+console.assert(false, "robert keeps %s on his balcony", {foo: "bar"})
+robert keeps [object Object] on his balcony
+
+Chrome:
+
+console.assert(false, "robert keeps %s on his balcony", {foo: "bar"})
+Assertion failed: robert keeps %s on his balcony Object {foo: "bar"}
+```

--- a/index.bs
+++ b/index.bs
@@ -169,7 +169,7 @@ By the time the printer operation is called, all format specifiers will have bee
 [NoInterfaceObject]
 interface Console {
   // Logging
-  void assert(boolean condition, optional any message);
+  void assert(boolean condition, optional any... data);
   void clear();
   void count(optional DOMString label = "");
   void debug(any... data);
@@ -201,9 +201,9 @@ partial interface WorkerGlobalScope {
 
 <h3 id="logging">Logging methods</h3>
 
-<h4><dfn method for="Console">assert(<var>condition</var>, <var>message</var>)</dfn></h4>
+<h4><dfn method for="Console">assert(<var>condition</var>, ...<var>data</var>)</dfn></h4>
 
-If <var>condition</var> is false, perform Logger("error", «<var>message</var>»).
+If <var>condition</var> is false, perform Logger("error", <var>data</var>).
 
 <h4><dfn method for="Console">clear()</dfn></h4>
 


### PR DESCRIPTION
 - Adds found differences for Chrome & Firefox.
 - Fixes method signature to support multiple arguments and not just one message. 

As the logger function is called if the assertion fails, console.assert MUST support format specifiers, which closes #4