### PR TITLE
Add [Replaceable] to the console attributes on Window/WorkerGlobalScope

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -201,11 +201,11 @@ interface Console {
 };
 
 partial interface Window {
-  attribute Console console;
+  [Replaceable] readonly attribute Console console;
 };
 
 partial interface WorkerGlobalScope {
-  attribute Console console;
+  [Replaceable] readonly attribute Console console;
 };
 </pre>
 


### PR DESCRIPTION
This is already the case in Blink and Gecko's IDL files:
https://chromium.googlesource.com/chromium/src/+/9efd0e84a8656f4782b4526491dde8482779f06e/third_party/WebKit/Source/core/frame/Window.idl#135
https://chromium.googlesource.com/chromium/src/+/da909b2dc9c92774e21e9e6a8eb7853aa3e97834/third_party/WebKit/Source/core/workers/WorkerGlobalScope.idl#46
https://hg.mozilla.org/mozilla-central/file/3f528e61aacf/dom/webidl/Window.webidl#l345
https://hg.mozilla.org/mozilla-central/file/ec85e0c7c060/dom/webidl/WorkerGlobalScope.webidl#l18

This issue came up when exposing the Console API to worklets:
https://codereview.chromium.org/1756623002/

Fixes https://github.com/whatwg/console/issues/1