### PR TITLE
Format NOTES, add time() differences

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -4,91 +4,106 @@ documenting the current status of affairs
 
 ## float formatter
 
-```
 FF:
 
+```js
 console.log("%f", 23)
-23,000000
+23.000000
+```
 
 Chrome:
 
+```js
 console.log("%f", 23)
 23
 ```
 
-```
 FF:
 
+```
 console.log('bjoern and robert are born on the %fst dec', 1.234)
-bjoern and robert are born on the 1,234000st dec
+bjoern and robert are born on the 1.234000st dec
+```
 
 Chrome:
 
+```
 console.log('bjoern and robert are born on the %fst dec', 1.234)
 bjoern and robert are born on the 1.234st dec
 ````
 
-```
 FF:
 
+```js
 console.log("%f", null)
-0,000000
+0.000000
+```
 
 Chrome:
 
+```js
 console.log("%f", null)
 NaN
 ```
 
 ## integer formatter
 
-```
 FF:
 
+```js
 console.log("%d", null)
 0
+```
 
 Chrome:
 
+```js
 console.log("%d", null)
 NaN
 ```
 
-```
 FF:
 
+```
 console.log('bjoern and robert are born on the %dst dec', "foo")
 bjoern and robert are born on the 0st dec
+```
 
 Chrome:
+
+```js
 console.log('bjoern and robert are born on the %dst dec', "foo")
 bjoern and robert are born on the NaNst dec
 ```
 
 ## not enough arguments to interpolate all placeholders
 
-```
 FF:
 
+```js
 console.log("%s %snewword", "duck")
 duck newword
+```
 
 Chrome:
 
+```js
 console.log("%s %snewword", "duck")
 duck %snewword
 ```
 
-## console.assert
+## console.assert - string formatter
 
-```
 FF / Edge:
 
+```js
 console.assert(false, "robert keeps %s on his balcony", "plaices")
 robert keeps plaices on his balcony
+```
 
 Chrome:
 
+```js
 console.assert(false, "robert keeps %s on his balcony", "plaices")
 Assertion failed: robert keeps %s on his balcony plaices
 ```
@@ -96,14 +111,16 @@ Assertion failed: robert keeps %s on his balcony plaices
 
 ## console.assert
 
-```
 FF / Edge:
 
+```js
 console.assert(false, "robert keeps %s on his balcony", {foo: "bar"})
 robert keeps [object Object] on his balcony
+```
 
 Chrome:
 
+```js
 console.assert(false, "robert keeps %s on his balcony", {foo: "bar"})
 Assertion failed: robert keeps %s on his balcony Object {foo: "bar"}
 ```
@@ -178,7 +195,6 @@ console.table([[1, 2, 3, 4], [5, 6, 7, 8]], 2, 3)
 
 ![Image of Firefox not displaying the table with additional arguments](images/notes/console-table-add-args-ff.png)
 
-
 Chrome:
 
 ```js
@@ -187,29 +203,22 @@ console.table([[1, 2, 3, 4], [5, 6, 7, 8]], 2, 3)
 
 ![Image of Chrome not displaying the table with additional arguments](images/notes/console-table-add-args-chrome.png)
 
+
 ## console.count - counters and label repetition
 
 Edge:
 
-```
+```js
 console.count('foo')
 undefined
 foo:           2
 console.count('foo')
 undefined
+```
 
-Chrome:
+FF / Chrome:
 
-console.count('foo')
-foo: 1
-undefined
-console.count('foo')
-foo: 2
-undefined
-
-
-FF:
-
+```js
 console.count('foo')
 foo: 1
 undefined
@@ -223,11 +232,11 @@ undefined
 *FF/Chrome: the label is printed multiple times with the current counter*
 
 
-## console.count - Arrays
+## console.count - objects / arrays
 
 Edge:
 
-```
+```js
 console.count({})
 undefined
 [object Object]: 1
@@ -235,9 +244,11 @@ undefined
 console.count([])
 undefined
 :           1
+```
 
 Chrome:
 
+```js
 console.count({})
 [object Object]: 1
 undefined
@@ -245,9 +256,11 @@ undefined
 console.count([])
 : 1
 undefined
+```
 
 FF:
 
+```js
 console.count({})
 [object Object]: 1
 undefined
@@ -261,20 +274,25 @@ undefined
 
 ## console.count - no arguments
 
-```
 Edge:
+
+```js
 console.count()
 undefined
 : 1
+```
 
 Chrome:
 
+```js
 console.count()
 : 1
 undefined
+```
 
 FF:
 
+```js
 console.count()
 <no label>: 1
 undefined
@@ -282,13 +300,11 @@ undefined
 
 *`<no label>` appears in FF*
 
-
 ## - no arguments / empty strings
 
-
-```
 Edge:
 
+```js
 console.count()
 : 1
 undefined
@@ -296,10 +312,11 @@ undefined
 console.count("")
 : 1
 undefined
-
+```
 
 Chrome:
 
+```js
 console.count()
 : 1
 undefined
@@ -307,10 +324,11 @@ undefined
 console.count("")
 : 2
 undefined
-
+```
 
 FF:
 
+```js
 console.count()
 <no label>: 1
 undefined
@@ -327,19 +345,23 @@ undefined
 
 Edge:
 
-```
+```js
 console.count(null)
 undefined
 : 2
+```
 
 Chrome:
 
+```js
 console.count(null)
 null: 2
 undefined
+```
 
 FF:
 
+```js
 console.count(null)
 null: 1
 undefined
@@ -349,25 +371,89 @@ undefined
 
 ## console.count - undefined
 
-```
 Edge:
 
+```js
 console.count(undefined)
 : 1
 undefined
-
+```
 
 Chrome:
 
+
+```js
 console.count(undefined)
 undefined: 1
 undefined
+```
 
 FF:
 
+```js
 console.count(undefined)
 undefined: 1
 undefined
 ```
 
 *Edge has no label*
+
+
+## console.time - no param/undefined
+
+FF:
+
+```js
+console.time() // no timer started
+console.time(undefined) // no timer started
+```
+
+Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1270636
+
+Chrome:
+
+```js
+console.time()
+console.time(undefined)
+
+console.timeEnd()
+default: <time in ms here>
+console.timeEnd()
+undefined: <time in ms here>
+```
+
+Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=696798
+
+## console.time - label conversion / conversion errors
+
+FF:
+
+```js
+console.time({ toString() {throw new Error("Farolino")} }) // toString called, no error thrown, no timer started
+```
+
+Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1343013
+
+Chrome:
+
+```js
+console.time({ toString() { return 'conversion' } }) // timer started with label `[object Object]`
+
+console.timeEnd('conversion')
+console.timeEnd({})
+[object Object]: <time in ms here>
+
+// ...
+
+console.time({ toString() { throw new Error("Farolino") } }) // toString never called, no timer started
+```
+
+Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=696805
+
+Edge:
+
+```js
+console.time({ toString() { throw new Error("Farolino") } }) // toString called, no error thrown, no timer started
+```
+
+Bug: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11201116/


### PR DESCRIPTION
Just formatting some of the content in notes, and adding the differences found with `time() / timeEnd()` and associated bugs. Will close https://github.com/whatwg/console/issues/26 when this is merged.

With changes like [this](https://github.com/whatwg/console/compare/update-notes?expand=1#diff-c7375ff11bc41bd2c1fbde6f98f5904aL11) I'm not sure if the comma was intentional or not, so I changed to a decimal (what I see as the output)