### PR TITLE
Add dir + dirxml to IDL and spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -195,7 +195,7 @@ namespace console { // but see namespace object requirements below
   void table(any tabularData, optional sequence&lt;DOMString> properties);
   void trace(any... data);
   void warn(any... data);
-  void dir(any data);
+  void dir(any item);
   void dirxml(any... data);
 
   // Grouping
@@ -287,11 +287,11 @@ Try to construct a table with the columns of the properties of <var>tabularData<
 
 Perform Logger("warn", <var>data</var>).
 
-<h4 id="dir" oldids="dir-data,dom-console-dir" method for="console">dir(<var>data</var>)</h4>
+<h4 id="dir" method for="console">dir(<var>item</var>)</h4>
 
-Let <var>object</var> be an potentially-interactive representation of <var>data</var> treated as a JavaScript object. Perform Printer("log", <var>«object»</var>).
+Let <var>object</var> be an potentially-interactive representation of <var>item</var> treated as a JavaScript object. Perform Printer("log", <var>«object»</var>).
 
-<h4 id="dirxml" oldids="dirxml-data,dom-console-dirxml" method for="console">dirxml(...<var>data</var>)</h4>
+<h4 id="dirxml" method for="console">dirxml(...<var>data</var>)</h4>
 
 <emu-alg>
   1. Let _finalList_ be a new <a>list</a>, initially empty.

--- a/index.bs
+++ b/index.bs
@@ -195,6 +195,8 @@ namespace console { // but see namespace object requirements below
   void table(any tabularData, optional sequence&lt;DOMString> properties);
   void trace(any... data);
   void warn(any... data);
+  void dir(any data);
+  void dirxml(any... data);
 
   // Grouping
   void group(any... data);
@@ -284,6 +286,18 @@ Try to construct a table with the columns of the properties of <var>tabularData<
 <h4 id="warn" oldids="warn-data,dom-console-warn" method for="console">warn(...<var>data</var>)</h4>
 
 Perform Logger("warn", <var>data</var>).
+
+<h4 id="dir" oldids="dir-data,dom-console-dir" method for="console">dir(<var>data</var>)</h4>
+
+Let <var>object</var> be an potentially-interactive representation of <var>data</var> treated as a JavaScript object. Perform Printer("log", <var>«object»</var>).
+
+<h4 id="dirxml" oldids="dirxml-data,dom-console-dirxml" method for="console">dirxml(...<var>data</var>)</h4>
+
+<emu-alg>
+  1. Let _finalList_ be a new <a>list</a>, initially empty.
+  1. For each _item_ of _data_, let _converted_ be a DOM tree representation of _item_ if possible, otherwise let _converted_ be an implementation-specific representation of _item_ judged to be maximally useful and informative. Append _converted_ to _finalList_.
+  1. Perform Printer("log", _finalList_).
+</emu-alg>
 
 <h3 id="grouping">Grouping methods</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -298,7 +298,9 @@ Perform Logger("warn", <var>data</var>).
 
 <emu-alg>
   1. Let _finalList_ be a new <a>list</a>, initially empty.
-  1. For each _item_ of _data_, let _converted_ be a DOM tree representation of _item_ if possible, otherwise let _converted_ be an implementation-specific representation of _item_ judged to be maximally useful and informative. Append _converted_ to _finalList_.
+  1. For each _item_ of _data_:
+    1. Let _converted_ be a DOM tree representation of _item_ if possible, otherwise let _converted_ be an implementation-specific representation of _item_ judged to be maximally useful and informative.
+    1. Append _converted_ to _finalList_.
   1. Perform Printer("log", _finalList_).
 </emu-alg>
 

--- a/index.bs
+++ b/index.bs
@@ -291,7 +291,7 @@ Perform Logger("warn", <var>data</var>).
 
 <emu-alg>
   1. Let <var>object</var> be an potentially-interactive representation of <var>item</var> treated as a JavaScript object.
-  1. Perform Printer("log", <var>«object»</var>).
+  1. Perform Printer("log", «_object_»).
 </emu-alg>
 
 <h4 id="dirxml" method for="console">dirxml(...<var>data</var>)</h4>

--- a/index.bs
+++ b/index.bs
@@ -289,7 +289,10 @@ Perform Logger("warn", <var>data</var>).
 
 <h4 id="dir" method for="console">dir(<var>item</var>)</h4>
 
-Let <var>object</var> be an potentially-interactive representation of <var>item</var> treated as a JavaScript object. Perform Printer("log", <var>«object»</var>).
+<emu-alg>
+  1. Let <var>object</var> be an potentially-interactive representation of <var>item</var> treated as a JavaScript object.
+  1. Perform Printer("log", <var>«object»</var>).
+</emu-alg>
 
 <h4 id="dirxml" method for="console">dirxml(...<var>data</var>)</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -312,7 +312,7 @@ the last <a>group</a> in a <a>group stack</a> will host output produced by calls
   1. Incorporate _groupLabel_ as a label for _group_.
   1. Optionally, if the environment supports interactive groups, _group_ should be expanded by default.
   1. Perform Printer("log", «_group_»).
-  1. <a spec="infra">Push</a> _group_ onto the appropriate <a>group stack</a>.
+  1. <a>Push</a> _group_ onto the appropriate <a>group stack</a>.
 </emu-alg>
 
 <h4 id="groupcollapsed" oldids="groupcollapsed-data,dom-console-groupcollapsed" method for="console">groupCollapsed(...<var>data</var>)</h4>
@@ -323,12 +323,12 @@ the last <a>group</a> in a <a>group stack</a> will host output produced by calls
   1. Incorporate _groupLabel_ as a label for _group_.
   1. Optionally, if the environment supports interactive groups, _group_ should be collapsed by default.
   1. Perform Printer("log", «_group_»).
-  1. <a spec="infra">Push</a> _group_ onto the appropriate <a>group stack</a>.
+  1. <a>Push</a> _group_ onto the appropriate <a>group stack</a>.
 </emu-alg>
 
 <h4 id="groupend" oldids="dom-console-groupend" method for="console">groupEnd()</h4>
 
-<a spec="infra">Pop</a> the last <a>group</a> from the <a>group stack</a>.
+<a>Pop</a> the last <a>group</a> from the <a>group stack</a>.
 
 <h3 id="timing">Timing methods</h3>
 


### PR DESCRIPTION
This adds language for `dir` and `dirxml` to the spec.

Whenever we call `Printer` in the spec it seems that we've already made the necessary transformations or conversions ourselves to the objects we're about to pass into `Printer`. To avoid duplication, `group` was defined outside of the methods that use it, therefore anything needing to print a group just says new `group` instead of new `view to host the output produced......`.

In `dirxml` I reused the `%o` format specifier description, and in `dir` I reused portions of the `%O` format specifier description; so I'm wondering if we should define things like:

 - `Generic JavaScript object representation`
and
 - `Optimally useful representation` (or similarly named)

somewhere near Printer so in the future we could say things like

 - "Let *converted* be a **generic JavaScript object** representation of *item*
or
 - "Let *converted* be *item* with **optimally useful formatting** applied.

Then for the two bullet-pointed terms above we could just pull some of the common words out between the definitions that exist already exist in the spec [here](https://console.spec.whatwg.org/#formatter) and [here](https://console.spec.whatwg.org/#formatting-specifiers).

Thoughts?