### PR TITLE
Factor out object formatting definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -141,7 +141,7 @@ The following is an informative summary of the format specifiers processed by th
 
 <h3 id="printer" aoid="Printer" nothrow>Printer(<var>logLevel</var>, <var>args</var>)</h3>
 
-The printer operation is implementation-defined. It accepts a log level indicating severity, and a List of arguments to print (which are either JavaScript objects, of any type, or are implementation-specific representations of printable things such as a stack trace, a <a>group</a>, or output produced by the <code>%o</code> and <code>%O</code> specifiers). How the implementation prints <var>args</var> is up to the implementation, but implementations should separate the objects by a space or something similar, as that has become a developer expectation.
+The printer operation is implementation-defined. It accepts a log level indicating severity, and a List of arguments to print (which are either JavaScript objects, of any type, or are implementation-specific representations of printable things such as a stack trace, a <a>group</a>, or objects with either <a>generic JavaScript object formatting</a> or <a>optimally useful formatting</a> applied). How the implementation prints <var>args</var> is up to the implementation, but implementations should separate the objects by a space or something similar, as that has become a developer expectation.
 
 By the time the printer operation is called, all format specifiers will have been taken into account, and any arguments that are meant to be consumed by format specifiers will not be present in <var>args</var>. The implementation's job is simply to print the List. The output produced by calls to Printer should appear only within the last <a>group</a> on the appropriate <a>group stack</a> if the <a>group stack</a> is not empty, or in the elsewhere in the console otherwise.
 
@@ -153,7 +153,7 @@ implementation-chosen limit (typically on the order of at least 100).
 
 Typically objects will be printed in a format that is suitable for their context. This section describes common ways in which objects are formatted to be most useful in their context.
 
-An object with <dfn>generic JavaScript object formatting</dfn> is a potentially expandable representation of a generic JavaScript object. An object with <dfn>optimally useful formatting</dfn> is an implementation-specific, potentially-interactive object judged to be maximally useful and informative.
+An object with <dfn>generic JavaScript object formatting</dfn> is a potentially expandable representation of a generic JavaScript object. An object with <dfn>optimally useful formatting</dfn> is an implementation-specific, potentially-interactive representation of an object judged to be maximally useful and informative.
 
 <h4 id="nodejs-printer">Example printer in Node.js</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -84,8 +84,8 @@ The formatter operation tries to format the first argument provided, using the o
     1. If _specifier_ is `%s`, let _converted_ be the result of ToString(_current_).
     1. If _specifier_ is `%d` or `%i`, let _converted_ be the result of %parseInt%(_current_, 10).
     1. If _specifier_ is `%f`, let _converted_ be the result of  %parseFloat%(_current_, 10).
-    1. If _specifier_ is `%o`, optionally let _converted_ be an implementation-specific representation of _current_ that is judged to be maximally useful and informative.
-    1. If _specifier_ is `%O`, optionally let _converted_ be be an implementation-specific representation of _current_ as an expanded or expandable object, treating _current_ as a generic JavaScript object.
+    1. If _specifier_ is `%o`, optionally let _converted_ be _current_ with <a>optimally useful formatting</a> applied.
+    1. If _specifier_ is `%O`, optionally let _converted_ be _current_ with <a>generic JavaScript object formatting</a> applied.
     1. <p class="XXX">TODO: process %c</p>
     1. If any of the previous steps set _converted_, replace _specifier_ in _target_ with _converted_.
     1. Let _result_ be a List containing _target_ together with the elements of _args_ starting from the third onward.
@@ -124,12 +124,12 @@ The following is an informative summary of the format specifiers processed by th
   </tr>
   <tr>
     <td><code>%o</code></td>
-    <td>Element is displayed in an implementation-specific way judged as most useful; potentially interactive</<td>
+    <td>Element is displayed with <a>optimally useful formatting</a></<td>
     <td>n/a</td>
   </tr>
   <tr>
     <td><code>%O</code></td>
-    <td>Element is displayed as an expanded JavaScript object; potentially interactive</<td>
+    <td>Element is displayed with <a>generic JavaScript object formatting</a></<td>
     <td>n/a</td>
   </tr>
   <tr>
@@ -148,6 +148,12 @@ By the time the printer operation is called, all format specifiers will have bee
 If the console is not open when the printer operation is called,
 implementations should buffer messages to show them in the future up to an
 implementation-chosen limit (typically on the order of at least 100).
+
+<h4 id="object-formats">Common Object Formats</h4>
+
+Typically objects will be printed in a format that is suitable for their context. This section describes common ways in which objects are formatted to be most useful in their context.
+
+An object with <dfn>generic JavaScript object formatting</dfn> is a potentially expandable representation of a generic JavaScript object. An object with <dfn>optimally useful formatting</dfn> is an implementation-specific, potentially-interactive object judged to be maximally useful and informative.
 
 <h4 id="nodejs-printer">Example printer in Node.js</h4>
 
@@ -290,7 +296,7 @@ Perform Logger("warn", <var>data</var>).
 <h4 id="dir" method for="console">dir(<var>item</var>)</h4>
 
 <emu-alg>
-  1. Let <var>object</var> be an potentially-interactive representation of <var>item</var> treated as a JavaScript object.
+  1. Let _object_ be _item_ with <a>generic JavaScript object formatting</a> applied.
   1. Perform Printer("log", «_object_»).
 </emu-alg>
 
@@ -299,7 +305,7 @@ Perform Logger("warn", <var>data</var>).
 <emu-alg>
   1. Let _finalList_ be a new <a>list</a>, initially empty.
   1. For each _item_ of _data_:
-    1. Let _converted_ be a DOM tree representation of _item_ if possible, otherwise let _converted_ be an implementation-specific representation of _item_ judged to be maximally useful and informative.
+    1. Let _converted_ be a DOM tree representation of _item_ if possible, otherwise let _converted_ be _item_ with <a>optimally useful formatting</a> applied.
     1. Append _converted_ to _finalList_.
   1. Perform Printer("log", _finalList_).
 </emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -151,7 +151,7 @@ implementation-chosen limit (typically on the order of at least 100).
 
 <h4 id="object-formats">Common Object Formats</h4>
 
-Typically objects will be printed in a format that is suitable for their context. This section describes common ways in which objects are formatted to be most useful in their context.
+Typically objects will be printed in a format that is suitable for their context. This section describes common ways in which objects are formatted to be most useful in their context. It should be noted that the formatting described in this section is applied to implementation-specific object representations that will eventually be passed into Printer, where the actual side effect of formatting will be seen.
 
 An object with <dfn>generic JavaScript object formatting</dfn> is a potentially expandable representation of a generic JavaScript object. An object with <dfn>optimally useful formatting</dfn> is an implementation-specific, potentially-interactive representation of an object judged to be maximally useful and informative.
 


### PR DESCRIPTION
First go at factoring out definitions we've duplicated in the spec when referring to the Printing of objects. Will close #97.

Originally I was going to put the dfns in the main Printer section but decided that just mashing them in between paras might not be the best way to keep that section clean.