### PR TITLE
Meta: add .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*    text=auto
+*.bs diff=html linguist-language=HTML


### PR DESCRIPTION
Part of https://github.com/whatwg/meta/issues/7.

I *believe* this will also instruct GitHub to wrap lines in .bs files by treating them as .html files. That should help reviewing a lot.

Alternately the spec could start wrapping at 100 characters like most WHATWG specs; not sure if that's worthwhile/what the editors want though.