### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15,6 +15,7 @@ Logo: https://resources.whatwg.org/logo-console.svg
 !Commits: <a href="https://github.com/whatwg/console/commits">GitHub whatwg/console/commits</a>
 !Commits: [SNAPSHOT-LINK]
 !Commits: <a href="https://twitter.com/consolelog">@consolelog</a>
+!Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/console>web-platform-tests console/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/console>ongoing work</a>)
 
 Opaque Elements: emu-alg
 </pre>


### PR DESCRIPTION
A few other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://xhr.spec.whatwg.org/