### PR TITLE
[#114] Specify map for console.count labels

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -373,6 +373,9 @@ its \[[Prototype]] an empty object, created as if by ObjectCreate(%ObjectPrototy
 
 <h3 id="logging">Logging methods</h3>
 
+Each {{console}} namespace object has an associated <dfn>count map</dfn>, which is a <a>map</a> of
+<a>strings</a> to labels, initially empty.
+
 <h4 id="assert" oldids="assert-condition-data,dom-console-assert" method for="console">assert(<var ignore=''>condition</var>, ...<var>data</var>)</h4>
 
 <emu-alg>
@@ -398,6 +401,8 @@ Otherwise, do nothing.
 <emu-alg>
   1. Let _called_ be the number of times _count_ has been invoked (including this invocation) with
   the provided _label_.
+    1. If the associated <a>count map</a> contains an entry with key _label_, <a for="map">set</a> the _value_ of map[_label_] to be map[_label_] + 1.
+    1. Else, <a for="map">set</a> the _value_ of the entry with key _label_ in the associated <a>count map</a> to be 1.
   1. Let _concat_ be the concatenation of _label_, U+003A COLON (:), U+0020 SPACE, and
   ToString(_called_).
   1. Perform Logger("count", _concat_).

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ Otherwise, do nothing.
 
 <emu-alg>
   1. Let _map_ be the associated <a>count map</a>.
-  1. If _map_[_label_] <a for="map">exists</a> in <a>map</a>, <a for="map">set</a> _map_[_label_] to _map_[_label_] + 1.
+  1. If _map_[_label_] <a for="map">exists</a>, <a for="map">set</a> _map_[_label_] to _map_[_label_] + 1.
   1. Otherwise, <a for="map">set</a> _map_[_label_] to 1.
   1. Let _concat_ be the concatenation of _label_, U+003A COLON (:), U+0020 SPACE, and
   ToString(_called_).

--- a/index.bs
+++ b/index.bs
@@ -399,10 +399,9 @@ Otherwise, do nothing.
 <h4 id="count" oldids="count-label,dom-console-count" method for="console">count(<var>label</var>)</h4>
 
 <emu-alg>
-  1. Let _called_ be the number of times _count_ has been invoked (including this invocation) with
-  the provided _label_.
-    1. If the associated <a>count map</a> contains an entry with key _label_, <a for="map">set</a> the _value_ of map[_label_] to be map[_label_] + 1.
-    1. Else, <a for="map">set</a> the _value_ of the entry with key _label_ in the associated <a>count map</a> to be 1.
+  1. Let _map_ be the associated count map.
+  1. If _map_[_label_] <a for="map">exists</a> in <a>map</a>, <a for="map">set</a> _map_[_label_] to _map_[_label_] + 1.
+  1. Otherwise, <a for="map">set</a> _map_[_label_] to 1.
   1. Let _concat_ be the concatenation of _label_, U+003A COLON (:), U+0020 SPACE, and
   ToString(_called_).
   1. Perform Logger("count", _concat_).

--- a/index.bs
+++ b/index.bs
@@ -404,7 +404,7 @@ Otherwise, do nothing.
   1. Otherwise, <a for="map">set</a> _map_[_label_] to 1.
   1. Let _concat_ be the concatenation of _label_, U+003A COLON (:), U+0020 SPACE, and
   ToString(_called_).
-  1. Perform Logger("count", _concat_).
+  1. Perform Logger("count", «_concat_»).
 </emu-alg>
 
 <h4 id="debug" oldids="debug-data,dom-console-debug" method for="console">debug(...<var>data</var>)</h4>

--- a/index.bs
+++ b/index.bs
@@ -399,7 +399,7 @@ Otherwise, do nothing.
 <h4 id="count" oldids="count-label,dom-console-count" method for="console">count(<var>label</var>)</h4>
 
 <emu-alg>
-  1. Let _map_ be the associated count map.
+  1. Let _map_ be the associated <a>count map</a>.
   1. If _map_[_label_] <a for="map">exists</a> in <a>map</a>, <a for="map">set</a> _map_[_label_] to _map_[_label_] + 1.
   1. Otherwise, <a for="map">set</a> _map_[_label_] to 1.
   1. Let _concat_ be the concatenation of _label_, U+003A COLON (:), U+0020 SPACE, and


### PR DESCRIPTION
Addresses https://github.com/whatwg/console/issues/114

Attempt to define `console.count()` label behavior by using an ordered map entry for each label:  https://infra.spec.whatwg.org/#maps

Specifies that a map object should be created, and that calls to count with that label should increment the value associated with the label.  If a label is undefined, a label passed to count will set the value of key _label_ to be 1.