### PR TITLE
Editorial: do not mention emu-algify in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ This specification is still in its very early stages. It is very much a work in 
 
 ## Building the spec
 
-The Console Standard is written in [Bikeshed](https://github.com/tabatkins/bikeshed), with an additional bit of help from [emu-algify](https://www.npmjs.com/package/emu-algify). The main source is in the file `index.bs`.
+The Console Standard is written in [Bikeshed](https://github.com/tabatkins/bikeshed). The main source is in the file `index.bs`.
 
-To build the standard locally, you will need a recent version of [Node.js](https://nodejs.org/en/). Run `npm install` in the root directory to set things up. Then you can either use a locally installed copy of [Bikeshed](https://github.com/tabatkins/bikeshed) by running `make` or use the HTTP API version by
- running `make remote`.
+To build the standard locally, you can either use a locally installed copy of [Bikeshed](https://github.com/tabatkins/bikeshed) by running `make` or use the HTTP API version by running `make remote`.
 
 If you want to do a complete "local deploy" including commit and/or branch snapshots, run
 


### PR DESCRIPTION
I didn't remove the `node_modules/` and `npm-debug.log` entries in `.gitignore`, because they might appear in `reference-implementation/` or `test/`.