### PR TITLE
Fix Formatter to use String() instead of ToString()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -35,6 +35,8 @@ urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: %parseInt%; url: sec-parseint-string-radix
   type: interface
     text: %ObjectPrototype%; url: sec-properties-of-the-object-prototype-object
+  type: constructor
+    text: String; url: sec-string-constructor
 </pre>
 
 <style>
@@ -283,7 +285,7 @@ more arguments are left. It returns a [=list=] of objects suitable for printing.
 1. Let |current| be the second element of |args|.
 1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
   1. If |specifier| is `%s`, let |converted| be the result of
-     <a abstract-op>ToString</a>(|current|).
+     <a constructor>String</a>(|current|).
   1. If |specifier| is `%d` or `%i`, let |converted| be the result of
      <a abstract-op>%parseInt%</a>(|current|, 10).
   1. If |specifier| is `%f`, let |converted| be the result of

--- a/index.bs
+++ b/index.bs
@@ -36,7 +36,7 @@ urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
   type: interface
     text: %ObjectPrototype%; url: sec-properties-of-the-object-prototype-object
   type: constructor
-    text: String; url: sec-string-constructor
+    text: %String%; url: sec-string-constructor
 </pre>
 
 <style>
@@ -285,7 +285,7 @@ more arguments are left. It returns a [=list=] of objects suitable for printing.
 1. Let |current| be the second element of |args|.
 1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
   1. If |specifier| is `%s`, let |converted| be the result of
-     <a constructor>String</a>(|current|).
+     <a constructor>%String%</a>(|current|).
   1. If |specifier| is `%d` or `%i`, let |converted| be the result of
      <a abstract-op>%parseInt%</a>(|current|, 10).
   1. If |specifier| is `%f`, let |converted| be the result of


### PR DESCRIPTION
First attempt at #113. I see two ways to go about this:

 - [Initial attempt] Use `String()` instead `ToString()` when Formatter converts arguments with the `%s` specifier. Behavior is the same as `ToString()` except it doesn't throw when converting Symbols. Not sure if this is a viable since `String()` isn't an abstract internal-only operating (are we limited to using these at all? Is it bag to call a constructor in this kinda position?)
 - Run a `Type()` check before we convert with `ToString()`, and call [`SymbolDescriptiveString`](https://tc39.github.io/ecma262/#sec-symboldescriptivestring) in the case we have a Symbol. (Basically performing the logic of the `String()` constructor ourselves).

Both of the above ways will prevent Formatter from throwing so the changes aren't big, and are pretty narrow in scope.

### Edit

I'll add some wpt for this as well once it is approved.