### PR TITLE
Meta: Add whatwg/meta references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,15 @@
 # Console Standard contributor guidelines
 
-These are the guidelines for contributing to the Console Standard. See the [WHATWG contributor guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).
+See the [WHATWG contributor guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).
+
+## Building the spec
+
+The Console Standard is written in [Bikeshed](https://github.com/tabatkins/bikeshed), and is available at https://console.spec.whatwg.org/. The main source is in the file `index.bs`.
+
+To build the standard locally, you can either use a locally installed copy of [Bikeshed](https://github.com/tabatkins/bikeshed) by running `make` or use the HTTP API version by running `make remote`.
+
+If you want to do a complete "local deploy" including commit and/or branch snapshots, run
+
+```
+make deploy
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Console Standard contributor guidelines
+
+These are the guidelines for contributing to the Console Standard. See the [WHATWG contributor guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Tests can be found in the `console/` directory of [web-platform-tests](https://g
 
 ## Contribution guidelines
 
-For guidelines on how to build and edit the spec, see [CONTRIBUTING.md](https://github.com/whatwg/console/blob/master/CONTRIBUTING.md).
+For guidelines on how to build and edit the spec, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Merge policy
+
+If you can commit to this repository, see the [WHATWG Maintainer Guidelines](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,13 @@ All web browsers, and most other JavaScript environments, have shipped some form
 
 A list containing some of the observed differences so far in different environments is available in [NOTES.md](NOTES.md).
 
-## Code of Conduct
-We are committed to providing a friendly, safe and welcoming environment for all. Please read and respect the [WHATWG Code of Conduct](https://whatwg.org/code-of-conduct).
-
 ## Work in progress
 
 This specification is still in its very early stages. It is very much a work in progress.
 
 ## Building the spec
 
-The Console Standard is written in [Bikeshed](https://github.com/tabatkins/bikeshed). The main source is in the file `index.bs`.
+The Console Standard is written in [Bikeshed](https://github.com/tabatkins/bikeshed), and is available at https://console.spec.whatwg.org/. The main source is in the file `index.bs`.
 
 To build the standard locally, you can either use a locally installed copy of [Bikeshed](https://github.com/tabatkins/bikeshed) by running `make` or use the HTTP API version by running `make remote`.
 
@@ -26,3 +23,11 @@ make deploy
 ## Tests
 
 Tests can be found in the `console/` directory of [web-platform-tests](https://github.com/w3c/web-platform-tests).
+
+## Contribution guidelines
+
+For guidelines on how to build and edit the spec, see [CONTRIBUTING.md](https://github.com/whatwg/console/blob/master/CONTRIBUTING.md).
+
+## Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for all. Please read and respect the [WHATWG Code of Conduct](https://whatwg.org/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -8,18 +8,6 @@ A list containing some of the observed differences so far in different environme
 
 This specification is still in its very early stages. It is very much a work in progress.
 
-## Building the spec
-
-The Console Standard is written in [Bikeshed](https://github.com/tabatkins/bikeshed), and is available at https://console.spec.whatwg.org/. The main source is in the file `index.bs`.
-
-To build the standard locally, you can either use a locally installed copy of [Bikeshed](https://github.com/tabatkins/bikeshed) by running `make` or use the HTTP API version by running `make remote`.
-
-If you want to do a complete "local deploy" including commit and/or branch snapshots, run
-
-```
-make deploy
-```
-
 ## Tests
 
 Tests can be found in the `console/` directory of [web-platform-tests](https://github.com/w3c/web-platform-tests).
@@ -32,6 +20,6 @@ For guidelines on how to build and edit the spec, see [CONTRIBUTING.md](CONTRIBU
 
 If you can commit to this repository, see the [WHATWG Maintainer Guidelines](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md).
 
-## Code of Conduct
+## Code of conduct
 
 We are committed to providing a friendly, safe and welcoming environment for all. Please read and respect the [WHATWG Code of Conduct](https://whatwg.org/code-of-conduct).


### PR DESCRIPTION
This:

 - Adds CONTRIBUTING.md (which directly references whatwg/meta's CONTRIBUTING.md and indirectly references whatwg/meta's COMMITTING.md)
 - Rearrange some stuff in README.md and reference the local CONTRIBUTING.md
 - Add `Merge policy` section to the README.md

Closes #125 