### PR TITLE
Use `Call` to call %parseInt/Float% and %String%

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -20,13 +20,14 @@ urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: ObjectCreate; url: sec-objectcreate
     text: Type; url: sec-ecmascript-data-types-and-values
     text: ToString; url: sec-tostring
-    text: %parseFloat%; url: sec-parsefloat-string
-    text: %parseInt%; url: sec-parseint-string-radix
     text: Call; url: sec-call
   type: interface
     text: %ObjectPrototype%; url: sec-properties-of-the-object-prototype-object
   type: constructor
     text: %String%; url: sec-string-constructor
+  type: dfn
+    text: %parseFloat%; url: sec-parsefloat-string
+    text: %parseInt%; url: sec-parseint-string-radix
 </pre>
 
 <h2 id="status" class="no-num no-toc">Status</h2>
@@ -267,11 +268,11 @@ more arguments are left. It returns a [=list=] of objects suitable for printing.
 1. Let |current| be the second element of |args|.
 1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
   1. If |specifier| is `%s`, let |converted| be the result of
-     <a abstract-op>Call<a>(<a constructor>%String%</a>, **undefined**, « |current| »).
+     <a abstract-op>Call<a>({{%String%}}, **undefined**, « |current| »).
   1. If |specifier| is `%d` or `%i`, let |converted| be the result of
-     <a abstract-op>Call</a>([$%parseInt%$], **undefined**, « |current|, 10 »).
+     <a abstract-op>Call</a>([=%parseInt%=], **undefined**, « |current|, 10 »).
   1. If |specifier| is `%f`, let |converted| be the result of
-     <a abstract-op>Call</a>([$%parseFloat%$], **undefined**, « |current| »).
+     <a abstract-op>Call</a>([=%parseFloat%=], **undefined**, « |current| »).
   1. If |specifier| is `%o`, optionally let |converted| be |current| with
      <a>optimally useful formatting</a> applied.
   1. If |specifier| is `%O`, optionally let |converted| be |current| with

--- a/index.bs
+++ b/index.bs
@@ -268,11 +268,11 @@ more arguments are left. It returns a [=list=] of objects suitable for printing.
 1. Let |current| be the second element of |args|.
 1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
   1. If |specifier| is `%s`, let |converted| be the result of
-     <a abstract-op>Call<a>({{%String%}}, **undefined**, « |current| »).
+     [$Call$]({{%String%}}, **undefined**, « |current| »).
   1. If |specifier| is `%d` or `%i`, let |converted| be the result of
-     <a abstract-op>Call</a>([=%parseInt%=], **undefined**, « |current|, 10 »).
+     [$Call$]([=%parseInt%=], **undefined**, « |current|, 10 »).
   1. If |specifier| is `%f`, let |converted| be the result of
-     <a abstract-op>Call</a>([=%parseFloat%=], **undefined**, « |current| »).
+     [$Call$]([=%parseFloat%=], **undefined**, « |current| »).
   1. If |specifier| is `%o`, optionally let |converted| be |current| with
      <a>optimally useful formatting</a> applied.
   1. If |specifier| is `%O`, optionally let |converted| be |current| with

--- a/index.bs
+++ b/index.bs
@@ -22,6 +22,7 @@ urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: ToString; url: sec-tostring
     text: %parseFloat%; url: sec-parsefloat-string
     text: %parseInt%; url: sec-parseint-string-radix
+    text: Call; url: sec-call
   type: interface
     text: %ObjectPrototype%; url: sec-properties-of-the-object-prototype-object
   type: constructor
@@ -266,11 +267,11 @@ more arguments are left. It returns a [=list=] of objects suitable for printing.
 1. Let |current| be the second element of |args|.
 1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
   1. If |specifier| is `%s`, let |converted| be the result of
-     <a constructor>%String%</a>(|current|).
+     <a abstract-op>Call<a>(<a constructor>%String%</a>, **undefined**, « |current| »).
   1. If |specifier| is `%d` or `%i`, let |converted| be the result of
-     <a abstract-op>%parseInt%</a>(|current|, 10).
+     <a abstract-op>Call</a>([$%parseInt%$], **undefined**, « |current|, 10 »).
   1. If |specifier| is `%f`, let |converted| be the result of
-     <a abstract-op>%parseFloat%</a>(|current|).
+     <a abstract-op>Call</a>([$%parseFloat%$], **undefined**, « |current| »).
   1. If |specifier| is `%o`, optionally let |converted| be |current| with
      <a>optimally useful formatting</a> applied.
   1. If |specifier| is `%O`, optionally let |converted| be |current| with


### PR DESCRIPTION
This fixes #126. I went with `Call(%String%...)` even though %String% does have the `[[Construct]]` internal method, because I saw no benefit to using `Construct(%String%...)` here as the `newTarget` is irrelevant.

## Edit

I prefer the bikeshed shorthand `[$Call$](...)` however I notice we don't always seem to use it in this spec. If anyone wants me to either revert this instance of the shorthand, or update all other links to use the shorthand (for the sake of consistency) I'm happy to do either.

Finally, I've used a bold **undefined** to denote `undefined` in ES, as it is passed into the `Call` abstract operation as the `this` value. Not sure if this is the *right* move, but I drew inspiration from the Streams Standard.