### PR TITLE
Ensure number format specifiers don't throw on Symbols

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -269,10 +269,14 @@ more arguments are left. It returns a [=list=] of objects suitable for printing.
 1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
   1. If |specifier| is `%s`, let |converted| be the result of
      [$Call$]({{%String%}}, **undefined**, « |current| »).
-  1. If |specifier| is `%d` or `%i`, let |converted| be the result of
-     [$Call$]([=%parseInt%=], **undefined**, « |current|, 10 »).
-  1. If |specifier| is `%f`, let |converted| be the result of
-     [$Call$]([=%parseFloat%=], **undefined**, « |current| »).
+  1. If |specifier| is `%d` or `%i`:
+    1. If [$Type$](|current|) is Symbol, let |converted| be `NaN`
+    1. Otherwise, let |converted| be the result of
+      [$Call$]([=%parseInt%=], **undefined**, « |current|, 10 »).
+  1. If |specifier| is `%f`:
+    1. If [$Type$](|current|) is Symbol, let |converted| be `NaN`
+    1. Otherwise, let |converted| be the result of
+      [$Call$]([=%parseFloat%=], **undefined**, « |current| »).
   1. If |specifier| is `%o`, optionally let |converted| be |current| with
      <a>optimally useful formatting</a> applied.
   1. If |specifier| is `%O`, optionally let |converted| be |current| with


### PR DESCRIPTION
Closes #113 and ensures that the Formatter will not throw an error when applying `%{i, d, f}` format specifiers when applied to Symbols. https://github.com/w3c/web-platform-tests/pull/9488 will need updated but I can get to that soon.