### PR TITLE
Fix leftover ToString reference in format specifier table's %s entry

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -314,7 +314,7 @@ The following is an informative summary of the format specifiers processed by th
   <tr>
     <td>`%s`</td>
     <td>Element which substitutes is converted to a string</td>
-    <td><a constructor>%String%</a>(|element|)</td>
+    <td><a idl>%String%</a>(|element|)</td>
   </tr>
   <tr>
     <td>`%d` or `%i`</td>

--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ more arguments are left. It returns a [=list=] of objects suitable for printing.
 1. Let |current| be the second element of |args|.
 1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
   1. If |specifier| is `%s`, let |converted| be the result of
-     [$Call$]({{%String%}}, **undefined**, « |current| »).
+     [$Call$](<a idl>%String%</a>, **undefined**, « |current| »).
   1. If |specifier| is `%d` or `%i`:
     1. If [$Type$](|current|) is Symbol, let |converted| be `NaN`
     1. Otherwise, let |converted| be the result of

--- a/index.bs
+++ b/index.bs
@@ -314,7 +314,7 @@ The following is an informative summary of the format specifiers processed by th
   <tr>
     <td>`%s`</td>
     <td>Element which substitutes is converted to a string</td>
-    <td><a abstract-op>ToString</a>(|element|)</td>
+    <td><a constructor>%String%</a>(|element|)</td>
   </tr>
   <tr>
     <td>`%d` or `%i`</td>

--- a/index.bs
+++ b/index.bs
@@ -523,6 +523,7 @@ Ian Kilpatrick,
 Jeff Carpenter,
 Joseph Pecoraro,
 Justin Woo,
+Luc Martin,
 Noah Bass,
 Paul Irish,
 Raphaël, and


### PR DESCRIPTION
Hello, I could find some time to work on this, though I am not experienced with Bikeshed.

There is another `%String%` reference in the spec, generated using the `{{%String%}}` syntax; however it appears as an orangered link, not a blue one like for the `%parseInt%` and `%parseFloat%` functions.

Is this behavior intended so I should have used the same syntax, or is there something to do about both references?
