### PR TITLE
Specify console.timeLog() + clean up timing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -68,8 +68,8 @@ namespace console { // but see namespace object requirements below
 
   // Timing
   void time(optional DOMString label = "default");
-  void timeEnd(optional DOMString label = "default");
   void timeLog(optional DOMString label = "default", any... data);
+  void timeEnd(optional DOMString label = "default");
 };
 </pre>
 
@@ -234,18 +234,6 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 1. Otherwise, [=map/set=] the value of the entry with key |label| in the associated
    <a>timer table</a> to the current time.
 
-<h4 id="timeend" oldids="timeend-label,dom-console-timeend" method for="console">timeEnd(|label|)</h4>
-
-1. Let |timerTable| be the associated <a>timer table</a>.
-1. Let |startTime| be |timerTable|[|label|].
-1. [=map/set|Remove=] |timerTable|[|label|].
-1. Let |duration| be a string representing the difference between the current time and
-   |startTime|, in an implementation-defined format.
-   <p class="example" id="duration-string-example">"4650", "4650.69 ms", "5 seconds", and "00:05"
-   are all reasonable ways of displaying a 4650.69 ms duration.</p>
-1. Let |concat| be the concatenation of |label|, U+003A (:), U+0020 SPACE, and |duration|.
-1. Perform <a abstract-op>Printer</a>("timeEnd", « |concat| »).
-
 <h4 id="timelog" method for="console">timeLog(|label|, ...|data|)</h4>
 
 1. Let |timerTable| be the associated <a>timer table</a>.
@@ -273,6 +261,18 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
     console.timeEnd("MyTimer");
   </code></pre>
 </div>
+
+<h4 id="timeend" oldids="timeend-label,dom-console-timeend" method for="console">timeEnd(|label|)</h4>
+
+1. Let |timerTable| be the associated <a>timer table</a>.
+1. Let |startTime| be |timerTable|[|label|].
+1. [=map/Remove=] |timerTable|[|label|].
+1. Let |duration| be a string representing the difference between the current time and
+   |startTime|, in an implementation-defined format.
+   <p class="example" id="duration-string-example">"4650", "4650.69 ms", "5 seconds", and "00:05"
+   are all reasonable ways of displaying a 4650.69 ms duration.</p>
+1. Let |concat| be the concatenation of |label|, U+003A (:), U+0020 SPACE, and |duration|.
+1. Perform <a abstract-op>Printer</a>("timeEnd", « |concat| »).
 
 <p class="note">See <a href="https://github.com/whatwg/console/issues/134">whatwg/console#134</a>
 for plans to make {{console/timeEnd()}} and {{console/timeLog()}} formally report warnings to the
@@ -428,7 +428,7 @@ their output similarly, in four broad categories. This table summarizes these co
     <td>log</td>
     <td>
       {{console/log()}}, {{console/trace()}}, {{console/dir()}}, {{console/dirxml()}},
-      {{console/group()}}, {{console/groupCollapsed()}}, {{console/debug()}} {{console/timeLog()}}
+      {{console/group()}}, {{console/groupCollapsed()}}, {{console/debug()}}, {{console/timeLog()}}
     </td>
     <td>
       A generic log

--- a/index.bs
+++ b/index.bs
@@ -240,6 +240,8 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 1. Let |startTime| be |timerTable|[|label|].
 1. Let |duration| be a string representing the difference between the current time and
    |startTime|, in an implementation-defined format.
+   <p class="example" id="duration-string-example">"4650", "4650.69 ms", "5 seconds", and "00:05"
+   are all reasonable ways of displaying a 4650.69 ms duration.</p>
 1. Let |concat| be the concatenation of |label|, U+003A (:), U+0020 SPACE, and |duration|.
 1. [=list/prepend|Prepend=] |concat| to |data|.
 1. Perform <a abstract-op>Printer</a>("timeLog", data).
@@ -251,13 +253,12 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 
   <pre><code class="lang-javascript">
     console.time("MyTimer");
-    console.timeLog("MyTimer", "Starting application up...");
+    console.timeLog("MyTimer", "Starting application up…");
     // Perhaps some code runs to boostrap a complex app
     // ...
     console.timeLog("MyTimer", "UI is setup, making API calls now");
     // Perhaps some fetch()'s here filling the app with data
     // ...
-    console.timeLog("MyTimer", "All done!");
     console.timeEnd("MyTimer");
   </code></pre>
 </div>
@@ -269,8 +270,6 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 1. [=map/Remove=] |timerTable|[|label|].
 1. Let |duration| be a string representing the difference between the current time and
    |startTime|, in an implementation-defined format.
-   <p class="example" id="duration-string-example">"4650", "4650.69 ms", "5 seconds", and "00:05"
-   are all reasonable ways of displaying a 4650.69 ms duration.</p>
 1. Let |concat| be the concatenation of |label|, U+003A (:), U+0020 SPACE, and |duration|.
 1. Perform <a abstract-op>Printer</a>("timeEnd", « |concat| »).
 

--- a/index.bs
+++ b/index.bs
@@ -69,6 +69,7 @@ namespace console { // but see namespace object requirements below
   // Timing
   void time(optional DOMString label = "default");
   void timeEnd(optional DOMString label = "default");
+  void timeLog(optional DOMString label = "default", any... data);
 };
 </pre>
 
@@ -78,8 +79,7 @@ namespace console { // but see namespace object requirements below
 
 <p class="note">
   It is important that {{console}} is always visible and usable to scripts, even if the developer
-  console has not been opened or
-  does not exist.
+  console has not been opened or does not exist.
 </p>
 
 For historical web-compatibility reasons, the <a>namespace object</a> for {{console}} must have as
@@ -236,14 +236,48 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 
 <h4 id="timeend" oldids="timeend-label,dom-console-timeend" method for="console">timeEnd(|label|)</h4>
 
-1. Let |startTime| be the result of [=map/getting=] the value of the entry with key |label| in the
-   associated <a>timer table</a>.
+1. Let |timerTable| be the associated <a>timer table</a>.
+1. Let |startTime| be |timerTable|[|label|].
+1. [=map/set|Remove=] |timerTable|[|label|].
 1. Let |duration| be a string representing the difference between the current time and
    |startTime|, in an implementation-defined format.
    <p class="example" id="duration-string-example">"4650", "4650.69 ms", "5 seconds", and "00:05"
    are all reasonable ways of displaying a 4650.69 ms duration.</p>
 1. Let |concat| be the concatenation of |label|, U+003A (:), U+0020 SPACE, and |duration|.
-1. Perform <a abstract-op>Logger</a>("timeEnd", « |concat| »).
+1. Perform <a abstract-op>Printer</a>("timeEnd", « |concat| »).
+
+<h4 id="timelog" method for="console">timeLog(|label|, ...|data|)</h4>
+
+1. Let |timerTable| be the associated <a>timer table</a>.
+1. Let |startTime| be |timerTable|[|label|].
+1. Let |duration| be a string representing the difference between the current time and
+   |startTime|, in an implementation-defined format.
+1. Let |concat| be the concatenation of |label|, U+003A (:), U+0020 SPACE, and |duration|.
+1. [=list/prepend|Prepend=] |concat| to |data|.
+1. Perform <a abstract-op>Printer</a>("timeLog", data).
+
+<div class="example" id="timelog-example">
+  The |data| parameter in calls to {{console/timeLog()}} is included in the call to
+  <a abstract-op>Logger</a> to make it easier for users to supply intermediate timer logs with
+  some extra data throughout the life of a timer. For example:
+
+  <pre><code class="lang-javascript">
+    console.time("MyTimer");
+    console.timeLog("MyTimer", "Starting application up...");
+    // Perhaps some code runs to boostrap a complex app
+    // ...
+    console.timeLog("MyTimer", "UI is setup, making API calls now");
+    // Perhaps some fetch()'s here filling the app with data
+    // ...
+    console.timeLog("MyTimer", "All done!");
+    console.timeEnd("MyTimer");
+  </code></pre>
+</div>
+
+<p class="note">See <a href="https://github.com/whatwg/console/issues/134">whatwg/console#134</a>
+for plans to make {{console/timeEnd()}} and {{console/timeLog()}} formally report warnings to the
+console when a give |label| does not exist in the associated <a>timer table</a>.
+</p>
 
 <h2 id="supporting-ops">Supporting abstract operations</h2>
 
@@ -394,7 +428,7 @@ their output similarly, in four broad categories. This table summarizes these co
     <td>log</td>
     <td>
       {{console/log()}}, {{console/trace()}}, {{console/dir()}}, {{console/dirxml()}},
-      {{console/group()}}, {{console/groupCollapsed()}}, {{console/debug()}}
+      {{console/group()}}, {{console/groupCollapsed()}}, {{console/debug()}} {{console/timeLog()}}
     </td>
     <td>
       A generic log

--- a/index.bs
+++ b/index.bs
@@ -276,7 +276,7 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 
 <p class="note">See <a href="https://github.com/whatwg/console/issues/134">whatwg/console#134</a>
 for plans to make {{console/timeEnd()}} and {{console/timeLog()}} formally report warnings to the
-console when a give |label| does not exist in the associated <a>timer table</a>.
+console when a given |label| does not exist in the associated <a>timer table</a>.
 </p>
 
 <h2 id="supporting-ops">Supporting abstract operations</h2>


### PR DESCRIPTION
This PR:

 - Adds `timeLog` to the Console Standard (and specifies that it should use `Printer` instead of `Logger` so we ignore format specifiers appearing in a timer label.
 - Cleans up the way we interact with associated `timer table`s in the timing methods - this is a little prep work for later when we check (non)existence of `timer table` entries so we can formally report warnings.
 - Points to an issue #134 to show plans for having the timing methods formally report warnings.
 - Fixes `timeEnd` to actually remove a timer from the timer table (the reason we went with adding `timeLog`)
 - Adds an example show how someone might use the extra `...data` passed into `timeLog` to distinguish calls to `timeLog` from each other throughout the duration of a timer.
 - Fixes `countReset`'s permalink to be all lowercase (that seems to be the trend here)
 - Closes #84 

Interested in getting some opinions from @xirzec, @nchevobbe, and @JosephPecoraro on this to make sure we have consensus and can get this in ASAP! (will file browser bugs soon)

Bugs
 - Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1461001
 - Safari: https://bugs.webkit.org/show_bug.cgi?id=186833
 - Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=854474
 - Edge: https://twitter.com/domfarolino/status/1009303140556931073