### PR TITLE
Report warning

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -550,6 +550,13 @@ representation of an object judged to be maximally useful and informative.
   </code></pre>
 </div>
 
+<h3 id="reporting-warnings">Reporting warnings to the console</h3>
+
+This specification defines the concept of <dfn export lt="report a warning">reporting a
+warning</dfn>, which can be used by other specifications when it is desireable to display a warning
+in the developer console. To <a>report a warning</a> given a generic implementation-defined warning,
+implementations must perform <a abstract-op>Printer</a>("reportWarning", « |warning| », |options|).
+
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 
 The editors would like to thank

--- a/index.bs
+++ b/index.bs
@@ -553,7 +553,7 @@ representation of an object judged to be maximally useful and informative.
 <h3 id="reporting-warnings">Reporting warnings to the console</h3>
 
 To <dfn export>report a warning to the console</dfn> given a generic description of a warning
-|description|, implementations must perform:
+|description|, implementations must run these steps:
 
 1. Let |warning| be an implementation-defined string derived from |description|.
 1. Perform <a abstract-op>Printer</a>("reportWarning", « |warning| »).

--- a/index.bs
+++ b/index.bs
@@ -554,8 +554,8 @@ representation of an object judged to be maximally useful and informative.
 
 This specification defines the concept of <dfn export lt="report a warning">reporting a
 warning</dfn>, which can be used by other specifications when it is desireable to display a warning
-in the developer console. To <a>report a warning</a> given a generic implementation-defined warning,
-implementations must perform <a abstract-op>Printer</a>("reportWarning", « |warning| », |options|).
+in the developer console. To <a>report a warning</a> given a generic implementation-defined warning
+|warning|, implementations must perform <a abstract-op>Printer</a>("reportWarning", « |warning| »).
 
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -552,11 +552,11 @@ representation of an object judged to be maximally useful and informative.
 
 <h3 id="reporting-warnings">Reporting warnings to the console</h3>
 
-This specification defines the concept of <dfn export lt="report a warning to the
-console">reporting a warning to the console</dfn>, which can be used by other specifications when
-it is desirable to display a warning in the developer console. To <a>report a warning to the
-console</a> given a generic implementation-defined warning |warning|, implementations must perform
-<a abstract-op>Printer</a>("reportWarning", « |warning| »).
+To <dfn export>report a warning to the console</dfn> given a generic description of a warning
+|description|, implementations must perform:
+
+1. Let |warning| be an implementation-defined string derived from |description|.
+1. Perform <a abstract-op>Printer</a>("reportWarning", « |warning| »).
 
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -552,10 +552,11 @@ representation of an object judged to be maximally useful and informative.
 
 <h3 id="reporting-warnings">Reporting warnings to the console</h3>
 
-This specification defines the concept of <dfn export lt="report a warning">reporting a
-warning</dfn>, which can be used by other specifications when it is desireable to display a warning
-in the developer console. To <a>report a warning</a> given a generic implementation-defined warning
-|warning|, implementations must perform <a abstract-op>Printer</a>("reportWarning", « |warning| »).
+This specification defines the concept of <dfn export lt="report a warning to the
+console">reporting a warning to the console</dfn>, which can be used by other specifications when
+it is desirable to display a warning in the developer console. To <a>report a warning to the
+console</a> given a generic implementation-defined warning |warning|, implementations must perform
+<a abstract-op>Printer</a>("reportWarning", « |warning| »).
 
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 


### PR DESCRIPTION
Closes #57. Not entirely familiar with creating an exportable definition in Bikeshed, but given some examples in whatwg/dom and friends I take it the `export` keyword is sufficient for Bikeshed to pick it up?

Also I'm happy to make a `ReportWarning(...)` abstract operation instead of just a dfn that can be given "a generic warning", but I figured I'd go down this route first.

Edit: #57 mentions it might be good to make this _optionally call Printer(...)_, but personally I prefer to make it mandatory, and have callers _optionally_ call into our definition. I think this will make their specs more clear.