### PR TITLE
Make first argument of `console.dir` and `console.table` optional (#159)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -51,10 +51,10 @@ namespace console { // but see namespace object requirements below
   void error(any... data);
   void info(any... data);
   void log(any... data);
-  void table(any tabularData, optional sequence&lt;DOMString> properties);
+  void table(optional any tabularData, optional sequence&lt;DOMString> properties);
   void trace(any... data);
   void warn(any... data);
-  void dir(any item, optional object? options);
+  void dir(optional any item, optional object? options);
   void dirxml(any... data);
 
   // Counting


### PR DESCRIPTION
WebKit, Chromium, and Gecko all support calling `console.dir` and `console.table` with no first argument (e.g. no exception is thrown), so the spec should match these implementations.  Given that every other `console` method allows for any number of arguments without throwing an error, it's reasonable to have `console.dir` and `console.table` do the same.

The implications of this is that `console.dir.length` and `console.table.length` would now be equal to `0`. 

```diff
 [Exposed=(Window,Worker,Worklet)]
 namespace console { // but see namespace object requirements below
   // Logging
   void assert(optional boolean condition = false, any... data);
   void clear();
   void debug(any... data);
   void error(any... data);
   void info(any... data);
   void log(any... data);
-  void table(any tabularData, optional sequence&lt;DOMString> properties);
+  void table(optional any tabularData, optional sequence&lt;DOMString> properties);
   void trace(any... data);
   void warn(any... data);
-  void dir(any item, optional object? options);
+  void dir(optional any item, optional object? options);
   void dirxml(any... data);
 
   // Counting
   void count(optional DOMString label = "default");
   void countReset(optional DOMString label = "default");
 
   // Grouping
   void group(any... data);
   void groupCollapsed(any... data);
   void groupEnd();
 
   // Timing
   void time(optional DOMString label = "default");
   void timeLog(optional DOMString label = "default", any... data);
   void timeEnd(optional DOMString label = "default");
 };
```

NOTE: this is why WebKit (and Gecko) is failing the [idlharness.any](https://wpt.fyi/results/console/idlharness.any.html) and [idlharness.worker.any](https://wpt.fyi/results/console/idlharness.any.worker.html) tests.