### PR TITLE
Handle input with no format specifiers in `Formatter`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -331,7 +331,6 @@ more arguments are left. It returns a [=/list=] of objects suitable for printing
      |converted|.
 1. Let |result| be a [=/list=] containing |target| together with the elements of |args| starting
    from the third onward.
-1. If |result|'s [=list/size=] is 1, return |result|.
 1. Return <a abstract-op>Formatter</a>(|result|).
 
 <h4 id="formatting-specifiers">Summary of formatting specifiers</h4>

--- a/index.bs
+++ b/index.bs
@@ -287,8 +287,6 @@ describes how it processes format specifiers while doing so.
 1. Let |rest| be all elements following |first| in |args|.
 1. If |rest| is [=list/is empty|empty=], perform
    <a abstract-op>Printer</a>(|logLevel|, « |first| ») and return.
-1. If |first| does not contain any format specifiers, perform
-   <a abstract-op>Printer</a>(|logLevel|, |args|).
 1. Otherwise, perform <a abstract-op>Printer</a>(|logLevel|, <a abstract-op>Formatter</a>(|args|)).
 1. Return *undefined*.
 
@@ -308,9 +306,12 @@ The formatter operation tries to format the first argument provided, using the o
 will try to format the input until no formatting specifiers are left in the first argument, or no
 more arguments are left. It returns a [=/list=] of objects suitable for printing.
 
+1. If |args|'s [=list/size=] is 1, return |args|.
 1. Let |target| be the first element of |args|.
 1. Let |current| be the second element of |args|.
 1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
+1. If no format specifier was found, return |args|.
+1. Otherwise:
   1. If |specifier| is `%s`, let |converted| be the result of
      [$Call$](<a idl>%String%</a>, **undefined**, « |current| »).
   1. If |specifier| is `%d` or `%i`:
@@ -328,9 +329,8 @@ more arguments are left. It returns a [=/list=] of objects suitable for printing
   1. <p class="XXX">TODO: process %c</p>
   1. If any of the previous steps set |converted|, replace |specifier| in |target| with
      |converted|.
-  1. Let |result| be a [=/list=] containing |target| together with the elements of |args| starting
-     from the third onward.
-1. If |target| does not have any format specifiers left, return |result|.
+1. Let |result| be a [=/list=] containing |target| together with the elements of |args| starting
+   from the third onward.
 1. If |result|'s [=list/size=] is 1, return |result|.
 1. Return <a abstract-op>Formatter</a>(|result|).
 


### PR DESCRIPTION
Hi! This is my first contribution to a spec like this so while I've done my best to follow the guidelines, there are probably things I am getting wrong. Let me know and I'll try and sort them out as soon as possible.

---

This fixes #204.

As noted in that issue, several functions call `Formatter` without
checking that a format specifier is present, but the `Formatter`
algorithm assumed this was never the case. When called in this way,
`Formatter` would use the `result` variable without defining it.

This patch makes the following changes:

- Add a step 4 to the `Formatter` algorithm to explicitly handle a lack
of format specifier.

- Correct the indentation of what was step 3.8 of `Formatter`, so it is
now step 6.

- Remove what was step 4 from `Formatter`, since this is now redundant.

- Remove step 5 from the `Logger` algorithm, since this is now
redundant.

- Add a new step 1 to `Formatter`, which returns early if only one
argument was provided.

---

<!--
Thank you for contributing to the Console Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * @terinjokes 
   * @domfarolino 
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * No tests added. This is a correction to the spec, to match what was already intended.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/console/205.html" title="Last updated on Dec 14, 2021, 10:32 AM UTC (aa06510)">Preview</a> | <a href="https://whatpr.org/console/205/6447e9d...aa06510.html" title="Last updated on Dec 14, 2021, 10:32 AM UTC (aa06510)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/console/205.html" title="Last updated on Sep 12, 2022, 10:18 AM UTC (a251358)">Preview</a> | <a href="https://whatpr.org/console/205/02a69ee...a251358.html" title="Last updated on Sep 12, 2022, 10:18 AM UTC (a251358)">Diff</a>