### PR TITLE
Add note about escaping `%`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -375,6 +375,11 @@ The following is an informative summary of the format specifiers processed by th
     <td>Applies provided CSS</td>
     <td>n/a</td>
   </tr>
+  <tr>
+    <td>`%%`</td>
+    <td>Escapes the `%` specifier</td>
+    <td>n/a</td>
+  </tr>
 </table>
 
 <h3 id="printer" abstract-op lt="Printer">Printer(|logLevel|, |args|[, |options|])</h3>


### PR DESCRIPTION
It looks like a bit of an interop issue:

Chrome:

<img width="161" alt="Screenshot 2022-12-06 at 12 01 42" src="https://user-images.githubusercontent.com/145676/205780094-c3125c29-e36c-43ca-a53f-434499877d0a.png">

Safari:

<img width="143" alt="Screenshot 2022-12-06 at 12 01 15" src="https://user-images.githubusercontent.com/145676/205780091-a964fc6c-6e18-46fc-95e4-4e54f1634d77.png">

Firefox:

<img width="158" alt="Screenshot 2022-12-06 at 12 01 26" src="https://user-images.githubusercontent.com/145676/205780093-645c23ac-c6b1-46e3-b5b2-1d9742763ca0.png">
