### PR TITLE
Handle BigInt with the `%d` and `%i` format specifiers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -17,6 +17,8 @@ urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: Type; url: sec-ecmascript-data-types-and-values
     text: ToString; url: sec-tostring
     text: Call; url: sec-call
+    for: BigInt
+      text: toString; url: sec-numeric-types-bigint-tostring
   type: interface
     text: %ObjectPrototype%; url: sec-properties-of-the-object-prototype-object
   type: constructor
@@ -315,11 +317,13 @@ more arguments are left. It returns a [=/list=] of objects suitable for printing
   1. If |specifier| is `%s`, let |converted| be the result of
      [$Call$](<a idl>%String%</a>, **undefined**, « |current| »).
   1. If |specifier| is `%d` or `%i`:
-    1. If [$Type$](|current|) is Symbol, let |converted| be `NaN`
+    1. If [$Type$](|current|) is Symbol, let |converted| be `NaN`.
+    1. Otherwise, if [$Type$](|current|) is BigInt, let |converted| be
+       [$BigInt/toString|BigInt::toString$](|current|, 10).
     1. Otherwise, let |converted| be the result of
       [$Call$]([=%parseInt%=], **undefined**, « |current|, 10 »).
   1. If |specifier| is `%f`:
-    1. If [$Type$](|current|) is Symbol, let |converted| be `NaN`
+    1. If [$Type$](|current|) is Symbol, let |converted| be `NaN`.
     1. Otherwise, let |converted| be the result of
       [$Call$]([=%parseFloat%=], **undefined**, « |current| »).
   1. If |specifier| is `%o`, optionally let |converted| be |current| with


### PR DESCRIPTION
This PR aims to close https://github.com/whatwg/console/issues/148 by including special-handling for `BigInt` in the `%d` and `%i` format specifier logic, that defers to the ECMAScript `BigInt::toString()` abstract operation, which provides a stringified representation of the BigInt that's optimal for that type.

 - Firefox already implements this behavior exactly
 - Safari _almost_ implements this; they add fancy commas that the `BigInt::toString()` abstract operation doesn't add
 - Node.js also _almost_ implements this PR, but adds the `n` suffix to the logged output, which this PR does not call for

All of those implementations specifically do not implement what is standardized right now, which is calling `%parseInt()%` on BigInts formatted with the `%d` and `%i` specifier, so the shortest path to interoperability is likely to change the spec here (and nudge other implementations to slightly modify their behavior to match this PR, which they're so close to doing). The only browser that implements the _current spec_ behavior is Chromium, and I personally like what the other implementations are doing better. The ecosystem has seemed to naturally drift in the the direction of the non-Chromium implementation too.

(The below template will be filled out provided this PR is acceptable).

- [ ] At least two implementers are interested (and none opposed):
   * Firefox (already implements this behavior)
   * Safari is quite close. We can see if they'd be willing to change to strictly adhere to this spec
   * Node.js is quite close. We can see if they'd be willing to change to strictly adhere to this spec
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Need manual tests
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)