### PR TITLE
Remove float parsing section of NOTES.md

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2,50 +2,6 @@
 
 documenting the current status of affairs
 
-## float formatter
-
-FF:
-
-```js
-console.log("%f", 23)
-23.000000
-```
-
-Chrome:
-
-```js
-console.log("%f", 23)
-23
-```
-
-FF:
-
-```
-console.log('bjoern and robert are born on the %fst dec', 1.234)
-bjoern and robert are born on the 1.234000st dec
-```
-
-Chrome:
-
-```
-console.log('bjoern and robert are born on the %fst dec', 1.234)
-bjoern and robert are born on the 1.234st dec
-````
-
-FF:
-
-```js
-console.log("%f", null)
-0.000000
-```
-
-Chrome:
-
-```js
-console.log("%f", null)
-NaN
-```
-
 ## integer formatter
 
 FF:


### PR DESCRIPTION
This PR makes some progress on #181 by removing the "Float parsing" section of NOTES.md. Firefox and _sometimes_ Safari deviate from the spec in a couple of ways, so I've filed bugs with their implementation to track the difference:
 - https://bugzilla.mozilla.org/show_bug.cgi?id=1846606
 - https://bugs.webkit.org/show_bug.cgi?id=259703