### PR TITLE
Add `console.timeStamp()` to the specification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -66,6 +66,7 @@ namespace console { // but see namespace object requirements below
   undefined time(optional DOMString label = "default");
   undefined timeLog(optional DOMString label = "default", any... data);
   undefined timeEnd(optional DOMString label = "default");
+  undefined timeStamp(optional DOMString label = "default");
 };
 </pre>
 
@@ -273,6 +274,12 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 for plans to make {{console/timeEnd()}} and {{console/timeLog()}} formally report warnings to the
 console when a given |label| does not exist in the associated <a>timer table</a>.
 </p>
+
+<h4 id="timestamp" oldids="timestamp-label,dom-console-timestamp" method for="console">timeStamp(|label|)</h4>
+
+1. If the developer is recording a performance trace, add a single marker to the performance trace with the |label|.
+1. Otherwise, do nothing.
+1. Return *undefined*.
 
 <h2 id="supporting-ops">Supporting abstract operations</h2>
 


### PR DESCRIPTION
This adds a minimal (vague) definition for the `timeStamp()` method, based on its current behavior across Chromium, Firefox, and Safari, and the MDN documentation[^1].

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/console/timestamp_static

Ref: #140

- [x] At least two implementers are interested (and none opposed):
   * Google
   * Mozilla
- [x] Implementations already exist:
   * Chromium
   * Geck
   * WebKit
- [x] [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/console/timestamp_static) already exists.
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.