### PR TITLE
Specify console.context

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -302,8 +302,8 @@ Each {{console}} namespace object has an associated <dfn>context name</dfn>, emp
 
 1. Let |context| be a new {{console}} namespace object.
 1. Let |contextName| be the empty string.
-1. If |label| is not null, let |contextName| be |label|.
-1. Let |context|'s <a>context name</a> be |contextName|.
+1. If |label| is not null, then set |contextName| to |label|.
+1. Set |context|'s <a>context name</a> to |contextName|.
 1. Return |context|.
 
 <h2 id="supporting-ops">Supporting abstract operations</h2>

--- a/index.bs
+++ b/index.bs
@@ -83,6 +83,9 @@ namespace console { // but see namespace object requirements below
   undefined time(optional DOMString label = "default");
   undefined timeLog(optional DOMString label = "default", any... data);
   undefined timeEnd(optional DOMString label = "default");
+
+  // Contextualizing
+  console context(optional DOMString label = "");
 };
 </pre>
 
@@ -290,6 +293,18 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 for plans to make {{console/timeEnd()}} and {{console/timeLog()}} formally report warnings to the
 console when a given |label| does not exist in the associated <a>timer table</a>.
 </p>
+
+<h3 id="contextualizing">Contextualizing</h3>
+
+Each {{console}} namespace object has an associated <dfn>context name</dfn>, empty by default.
+
+<h4 id="context" method for="console">context(|label|)</h4>
+
+1. Let |context| be a new {{console}} namespace object.
+1. Let |contextName| be the empty string.
+1. If |label| is not null, let |contextName| be |label|.
+1. Let |context|'s <a>context name</a> be |contextName|.
+1. Return |context|.
 
 <h2 id="supporting-ops">Supporting abstract operations</h2>
 
@@ -512,6 +527,9 @@ enhancements:
       <img alt="Indicating UI that allows filtering by log severity" width="494" height="58"
       src="images/severity-filter.png">
     </div>
+  </li>
+  <li>
+    Extra UI allowing the user to filter messages by context name
   </li>
   <li>
     Extra UI off to the side indicating the current state of the <a>timer table</a>,

--- a/index.bs
+++ b/index.bs
@@ -85,7 +85,7 @@ namespace console { // but see namespace object requirements below
   undefined timeEnd(optional DOMString label = "default");
 
   // Contextualizing
-  console context(optional DOMString label = "");
+  ConsoleContext context(optional DOMString label = "");
 };
 </pre>
 
@@ -104,7 +104,7 @@ its \[[Prototype]] an empty object, created as if by
 
 <h3 id="logging">Logging functions</h3>
 
-<h4 id="assert" oldids="assert-condition-data,dom-console-assert" method for="console">assert(|condition|, ...|data|)</h4>
+<h4 id="assert" oldids="assert-condition-data,dom-console-assert" method for="console,ConsoleContext">assert(|condition|, ...|data|)</h4>
 
 1. If |condition| is true, return.
 1. Let |message| be a string without any formatting specifiers indicating generically an assertion
@@ -118,28 +118,28 @@ its \[[Prototype]] an empty object, created as if by
     1. Set |data|[0] to |concat|.
 1. Perform <a abstract-op>Logger</a>("assert", |data|).
 
-<h4 id="clear" oldids="dom-console-clear" method for="console">clear()</h4>
+<h4 id="clear" oldids="dom-console-clear" method for="console,ConsoleContext">clear()</h4>
 
 1. [=stack/Empty=] the appropriate <a>group stack</a>.
 1. If possible for the environment, clear the console. (Otherwise, do nothing.)
 
-<h4 id="debug" oldids="debug-data,dom-console-debug" method for="console">debug(...|data|)</h4>
+<h4 id="debug" oldids="debug-data,dom-console-debug" method for="console,ConsoleContext">debug(...|data|)</h4>
 
 1. Perform <a abstract-op>Logger</a>("debug", |data|).
 
-<h4 id="error" oldids="error-data,dom-console-error" method for="console">error(...|data|)</h4>
+<h4 id="error" oldids="error-data,dom-console-error" method for="console,ConsoleContext">error(...|data|)</h4>
 
 1. Perform <a abstract-op>Logger</a>("error", |data|).
 
-<h4 id="info" oldids="info-data,dom-console-info" method for="console">info(...|data|)</h4>
+<h4 id="info" oldids="info-data,dom-console-info" method for="console,ConsoleContext">info(...|data|)</h4>
 
 1. Perform <a abstract-op>Logger</a>("info", |data|).
 
-<h4 id="log" oldids="log-data,dom-console-log" method for="console">log(...|data|)</h4>
+<h4 id="log" oldids="log-data,dom-console-log" method for="console,ConsoleContext">log(...|data|)</h4>
 
 1. Perform <a abstract-op>Logger</a>("log", |data|).
 
-<h4 id="table" oldids="table-tabulardata-properties,dom-console-table" method for="console">table(|tabularData|, |properties|)</h4>
+<h4 id="table" oldids="table-tabulardata-properties,dom-console-table" method for="console,ConsoleContext">table(|tabularData|, |properties|)</h4>
 
 Try to construct a table with the columns of the properties of |tabularData| (or use
 |properties|) and rows of |tabularData| and log it with a logLevel of "log". Fall
@@ -147,7 +147,7 @@ back to just logging the argument if it can't be parsed as tabular.
 
 <p class="XXX">TODO: This will need a good algorithm.</p>
 
-<h4 id="trace" oldids="trace-data,dom-console-trace" method for="console">trace(...|data|)</h4>
+<h4 id="trace" oldids="trace-data,dom-console-trace" method for="console,ConsoleContext">trace(...|data|)</h4>
 
 1. Let |trace| be some <a>implementation-defined</a>, potentially-interactive representation of the
    callstack from where this function was called.
@@ -160,16 +160,16 @@ back to just logging the argument if it can't be parsed as tabular.
   not guaranteed to be the same identifier that would be seen in `new Error().stack`.
 </p>
 
-<h4 id="warn" oldids="warn-data,dom-console-warn" method for="console">warn(...|data|)</h4>
+<h4 id="warn" oldids="warn-data,dom-console-warn" method for="console,ConsoleContext">warn(...|data|)</h4>
 
 1. Perform <a abstract-op>Logger</a>("warn", |data|).
 
-<h4 id="dir" method for="console">dir(|item|, |options|)</h4>
+<h4 id="dir" method for="console,ConsoleContext">dir(|item|, |options|)</h4>
 
 1. Let |object| be |item| with <a>generic JavaScript object formatting</a> applied.
 1. Perform <a abstract-op>Printer</a>("dir", « |object| », |options|).
 
-<h4 id="dirxml" method for="console">dirxml(...|data|)</h4>
+<h4 id="dirxml" method for="console,ConsoleContext">dirxml(...|data|)</h4>
 
 1. Let |finalList| be a new [=/list=], initially empty.
 1. [=list/For each=] |item| of |data|:
@@ -180,10 +180,10 @@ back to just logging the argument if it can't be parsed as tabular.
 
 <h3 id="counting">Counting functions</h3>
 
-Each {{console}} namespace object has an associated <dfn>count map</dfn>, which is a <a>map</a> of
+Each {{console}} namespace object and {{ConsoleContext}} instance has an associated <dfn>count map</dfn>, which is a <a>map</a> of
 <a>strings</a> to numbers, initially empty.
 
-<h4 id="count" oldids="count-label,dom-console-count" method for="console">count(|label|)</h4>
+<h4 id="count" oldids="count-label,dom-console-count" method for="console,ConsoleContext">count(|label|)</h4>
 
 1. Let |map| be the associated <a>count map</a>.
 1. If |map|[|label|] [=map/exists=], [=map/set=] |map|[|label|] to |map|[|label|] + 1.
@@ -192,7 +192,7 @@ Each {{console}} namespace object has an associated <dfn>count map</dfn>, which 
    <a abstract-op>ToString</a>(|map|[|label|]).
 1. Perform <a abstract-op>Logger</a>("count", « |concat| »).
 
-<h4 id="countreset" method for="console">countReset(|label|)</h4>
+<h4 id="countreset" method for="console,ConsoleContext">countReset(|label|)</h4>
 
 1. Let |map| be the associated <a>count map</a>.
 1. If |map|[|label|] [=map/exists=], [=map/set=] |map|[|label|] to 0.
@@ -205,11 +205,11 @@ Each {{console}} namespace object has an associated <dfn>count map</dfn>, which 
 
 A <dfn id="concept-group">group</dfn> is an <a>implementation-defined</a>, potentially-interactive
 view for output produced by calls to <a abstract-op>Printer</a>, with one further level of
-indentation than its parent. Each {{console}} namespace object has an associated <dfn>group
+indentation than its parent. Each {{console}} namespace object and {{ConsoleContext}} instance has an associated <dfn>group
 stack</dfn>, which is a <a>stack</a>, initially empty. Only the last <a>group</a> in a <a>group
 stack</a> will host output produced by calls to <a abstract-op>Printer</a>.
 
-<h4 id="group" oldids="group-data,dom-console-group" method for="console">group(...|data|)</h4>
+<h4 id="group" oldids="group-data,dom-console-group" method for="console,ConsoleContext">group(...|data|)</h4>
 
 1. Let |group| be a new <a>group</a>.
 1. If |data| is not [=list/is empty|empty=], let |groupLabel| be the result of
@@ -221,7 +221,7 @@ stack</a> will host output produced by calls to <a abstract-op>Printer</a>.
 1. Perform <a abstract-op>Printer</a>("group", « |group| »).
 1. [=stack/Push=] |group| onto the appropriate <a>group stack</a>.
 
-<h4 id="groupcollapsed" oldids="groupcollapsed-data,dom-console-groupcollapsed" method for="console">groupCollapsed(...|data|)</h4>
+<h4 id="groupcollapsed" oldids="groupcollapsed-data,dom-console-groupcollapsed" method for="console,ConsoleContext">groupCollapsed(...|data|)</h4>
 
 1. Let |group| be a new <a>group</a>.
 1. If |data| is not empty, let |groupLabel| be the result of
@@ -233,7 +233,7 @@ stack</a> will host output produced by calls to <a abstract-op>Printer</a>.
 1. Perform <a abstract-op>Printer</a>("groupCollapsed", « |group| »).
 1. [=stack/Push=] |group| onto the appropriate <a>group stack</a>.
 
-<h4 id="groupend" oldids="dom-console-groupend" method for="console">groupEnd()</h4>
+<h4 id="groupend" oldids="dom-console-groupend" method for="console,ConsoleContext">groupEnd()</h4>
 
 1. <a>Pop</a> the last <a>group</a> from the <a>group stack</a>.
 
@@ -242,7 +242,7 @@ stack</a> will host output produced by calls to <a abstract-op>Printer</a>.
 Each {{console}} namespace object has an associated <dfn>timer table</dfn>, which is a <a>map</a> of
 <a>strings</a> to times, initially empty.
 
-<h4 id="time" oldids="time-label,dom-console-time" method for="console">time(|label|)</h4>
+<h4 id="time" oldids="time-label,dom-console-time" method for="console,ConsoleContext">time(|label|)</h4>
 
 1. If the associated <a>timer table</a> [=map/contains=] an entry with key |label|, return,
    optionally reporting a warning to the console indicating that a timer with label |label| has
@@ -250,7 +250,7 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
 1. Otherwise, [=map/set=] the value of the entry with key |label| in the associated
    <a>timer table</a> to the current time.
 
-<h4 id="timelog" method for="console">timeLog(|label|, ...|data|)</h4>
+<h4 id="timelog" method for="console,ConsoleContext">timeLog(|label|, ...|data|)</h4>
 
 1. Let |timerTable| be the associated <a>timer table</a>.
 1. Let |startTime| be |timerTable|[|label|].
@@ -279,7 +279,7 @@ Each {{console}} namespace object has an associated <dfn>timer table</dfn>, whic
   </code></pre>
 </div>
 
-<h4 id="timeend" oldids="timeend-label,dom-console-timeend" method for="console">timeEnd(|label|)</h4>
+<h4 id="timeend" oldids="timeend-label,dom-console-timeend" method for="console,ConsoleContext">timeEnd(|label|)</h4>
 
 1. Let |timerTable| be the associated <a>timer table</a>.
 1. Let |startTime| be |timerTable|[|label|].
@@ -296,15 +296,51 @@ console when a given |label| does not exist in the associated <a>timer table</a>
 
 <h3 id="contextualizing">Contextualizing</h3>
 
-Each {{console}} namespace object has an associated <dfn>context name</dfn>, empty by default.
+Each {{ConsoleContext}} instance has an associated <dfn>context name</dfn>, empty by default.
 
 <h4 id="context" method for="console">context(|label|)</h4>
 
-1. Let |context| be a new {{console}} namespace object.
+1. Let |context| be a new {{ConsoleContext}} instance.
 1. Let |contextName| be the empty string.
 1. If |label| is not null, then set |contextName| to |label|.
 1. Set |context|'s <a>context name</a> to |contextName|.
 1. Return |context|.
+
+<h2 id="the-consolecontext-interface">The {{ConsoleContext}} interface</h2>
+
+The IDL for the {{ConsoleContext}} interface is as follows, with the various methods defined in the {{console}} section:
+
+<pre class="idl">
+[Exposed=*]
+interface ConsoleContext {
+  // Logging
+  undefined assert(optional boolean condition = false, any... data);
+  undefined clear();
+  undefined debug(any... data);
+  undefined error(any... data);
+  undefined info(any... data);
+  undefined log(any... data);
+  undefined table(optional any tabularData, optional sequence&lt;DOMString> properties);
+  undefined trace(any... data);
+  undefined warn(any... data);
+  undefined dir(optional any item, optional object? options);
+  undefined dirxml(any... data);
+
+  // Counting
+  undefined count(optional DOMString label = "default");
+  undefined countReset(optional DOMString label = "default");
+
+  // Grouping
+  undefined group(any... data);
+  undefined groupCollapsed(any... data);
+  undefined groupEnd();
+
+  // Timing
+  undefined time(optional DOMString label = "default");
+  undefined timeLog(optional DOMString label = "default", any... data);
+  undefined timeEnd(optional DOMString label = "default");
+};
+</pre>
 
 <h2 id="supporting-ops">Supporting abstract operations</h2>
 


### PR DESCRIPTION
This specifies the console.context(label) method which returns a new console namespace object with an optional context name label.

Tests: TODO

Fixes #193

---

- [x] At least two implementers are interested (and none opposed):
   * Chrome is shipping the method already 
   * Mozilla is interested
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * TODO (waiting to get some feedback on the PR before looking into writing tests)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/40523727
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1948870
   * Node.js: https://github.com/nodejs/node/issues/56634 (Node.js does have support for `console.context()` but logging with returned instance doesn't print anything. Linked issue mentions the lack of spec for the method).
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=293768
   * Deno:https://github.com/denoland/deno/issues/29560
- [x] MDN issue: https://github.com/mdn/mdn/issues/692
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/console/244.html" title="Last updated on Nov 17, 2025, 8:35 AM UTC (5da9ceb)">Preview</a> | <a href="https://whatpr.org/console/244/6f299db...5da9ceb.html" title="Last updated on Nov 17, 2025, 8:35 AM UTC (5da9ceb)">Diff</a>