### PR TITLE
Do not process format specifiers introduced by substitutions (#250)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -322,15 +322,21 @@ describes how it processes format specifiers while doing so.
 <h3 id="formatter" abstract-op lt="Formatter">Formatter(|args|)</h3>
 
 The formatter operation tries to format the first argument provided, using the other arguments. It
-will try to format the input until no formatting specifiers are left in the first argument, or no
-more arguments are left. It returns a [=/list=] of objects suitable for printing.
+will process formatting specifiers in the first argument from left to right until no formatting
+specifiers remain or no more arguments are left. Formatting specifiers introduced by converted
+values are not processed. It returns a [=/list=] of objects suitable for printing.
 
 1. If |args|'s [=list/size=] is 1, return |args|.
 1. Let |target| be the first element of |args|.
-1. Let |current| be the second element of |args|.
-1. Find the first possible format specifier |specifier|, from the left to the right in |target|.
-1. If no format specifier was found, return |args|.
-1. Otherwise:
+1. If |target| [=is not a String=], return |args|.
+1. Let |position| be the start of |target|.
+1. Let |currentIndex| be 1.
+1. While |currentIndex| is less than |args|'s [=list/size=]:
+  1. Find the first possible format specifier |specifier|, from the left to the right in |target|,
+     starting at |position|.
+  1. If no format specifier was found, break.
+  1. Let |current| be |args|[|currentIndex|].
+  1. Let |converted| be unset.
   1. If |specifier| is `%s`, let |converted| be the result of
      [$Call$](<a idl>%String%</a>, **undefined**, « |current| »).
   1. If |specifier| is `%d` or `%i`:
@@ -346,11 +352,19 @@ more arguments are left. It returns a [=/list=] of objects suitable for printing
   1. If |specifier| is `%O`, optionally let |converted| be |current| with
      <a>generic JavaScript object formatting</a> applied.
   1. <p class="XXX">TODO: process %c</p>
-  1. If any of the previous steps set |converted|, replace |specifier| in |target| with
-     |converted|.
-1. Let |result| be a [=/list=] containing |target| together with the elements of |args| starting
-   from the third onward.
-1. Return <a abstract-op>Formatter</a>(|result|).
+  1. If |converted| is set:
+    1. Replace the occurrence of |specifier| found in the previous step in |target| with
+       |converted|.
+    1. Set |position| to the position in |target| immediately following the inserted |converted|.
+  1. Otherwise, set |position| to the position immediately following |specifier| in |target|.
+  1. Set |currentIndex| to |currentIndex| + 1.
+1. Return a [=/list=] containing |target| together with the elements of |args| starting at index
+   |currentIndex|.
+
+<div class="example" id="formatter-substitution-example">
+  For example, <a abstract-op>Formatter</a>(« "%s", "hello %s world", 1 ») returns
+  « "hello %s world", 1 ». The format specifier introduced by the second argument is not processed.
+</div>
 
 <h4 id="formatting-specifiers">Summary of formatting specifiers</h4>
 
@@ -589,6 +603,7 @@ Jeff Carpenter,
 Joseph Pecoraro,
 Justin Woo,
 Luc Martin,
+Michael Reeves,
 Noah Bass,
 Paul Irish,
 Raphaël, and


### PR DESCRIPTION
The Formatter algorithm currently rescans converted values. As a result, a string substitution can introduce new format specifiers that unexpectedly consume subsequent arguments.

Process only format specifiers present in the initial target, preserving substituted text verbatim. Explicitly return the arguments unchanged when the initial target is not a String.

Fixes #250.

---

Hi! This is my first time contributing so I hope I did everything right, and am happy to fix anything if I didn't. 

I have signed the [Participant Agreement](https://github.com/whatwg/participant-data/commit/cd4165eaf1720d288e5de1ff0695625ea36ef8c7), but someone needs to go in and set me to verified: true I think.

This spec change aligns with the behaviour already implemented in Gecko, WebKit, Deno, and Node. Chromium is being updated in [CL 8223707](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/8223707).

The existing [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/console#using_string_substitutions) remains accurate and does not specify recursive processing, so I do not believe a documentation update is required.

Thank you for your time in reviewing!

---
<!--
Thank you for contributing to the Console Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Gecko and WebKit already implement the proposed behaviour.
   * Deno and Node.js also implement it.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/61825
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/543972096
     ([implementation CL](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/8223707))
   * Gecko: N/A — already implements this behaviour
   * WebKit: N/A — already implements this behaviour
   * Deno: N/A — already implements this behaviour
   * Node.js: N/A — already implements this behaviour
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A — the existing documentation remains accurate and does not define recursive processing.
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/console/254.html" title="Last updated on Aug 8, 2026, 1:33 PM UTC (25190d0)">Preview</a> | <a href="https://whatpr.org/console/254/a82403e...25190d0.html" title="Last updated on Aug 8, 2026, 1:33 PM UTC (25190d0)">Diff</a>